### PR TITLE
fix: disable Next.js cache on export fetch to avoid Node.js streaming crash

### DIFF
--- a/src/features/lieux-inclusion-numerique/abilities/export/query/fetch-all-lieux.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/export/query/fetch-all-lieux.ts
@@ -10,9 +10,14 @@ import {
 export const fetchAllLieux =
   (collectivite?: Collectivite) =>
   async (filters: FiltersSchema): Promise<LieuxRouteResponse> => {
-    const [lieux] = await inclusionNumeriqueFetchApi(LIEUX_ROUTE, {
-      filter: buildCollectiviteFilter(filters, collectivite),
-      order: ['nom', 'asc']
-    });
+    const [lieux] = await inclusionNumeriqueFetchApi(
+      LIEUX_ROUTE,
+      {
+        filter: buildCollectiviteFilter(filters, collectivite),
+        order: ['nom', 'asc']
+      },
+      undefined,
+      { noCache: true }
+    );
     return lieux;
   };


### PR DESCRIPTION
The export CSV fetch returns ~3.3 MB which exceeds Next.js 2 MB cache limit, causing repeated uncacheable fetches through the streaming pipeline. This triggers a known Node.js 22 bug
(controller[kState].transformAlgorithm is not a function) that crashes the server. Using noCache bypasses the streaming/cache pipeline entirely.