### PR TITLE
fix: fix container startup for Scaleway deployment

### DIFF
--- a/infrastructure/nginx/entrypoint.sh
+++ b/infrastructure/nginx/entrypoint.sh
@@ -3,26 +3,19 @@
 node server.js &
 NODE_PID=$!
 
+nginx -g 'daemon off;' &
+NGINX_PID=$!
+
 crowdsec -c /etc/crowdsec/config.yaml &
 CROWDSEC_PID=$!
 
-# Attendre que le LAPI CrowdSec soit pret
-for i in $(seq 1 30); do
-    if wget -qO /dev/null http://127.0.0.1:8080/health 2>/dev/null; then
-        echo "CrowdSec LAPI ready"
-        break
-    fi
-    sleep 1
-done
-
 stop() {
     nginx -s quit
-    kill "$CROWDSEC_PID" "$NODE_PID"
-    wait "$CROWDSEC_PID" "$NODE_PID"
+    kill "$CROWDSEC_PID" "$NODE_PID" 2>/dev/null
+    wait "$CROWDSEC_PID" "$NODE_PID" 2>/dev/null
     exit 0
 }
 
 trap stop TERM INT
 
-nginx -g 'daemon off;' &
-wait $!
+wait $NGINX_PID

--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -68,7 +68,12 @@ http {
     lua_shared_dict crowdsec_cache 50m;
 
     init_by_lua_block {
-        cs = require "crowdsec"
+        crowdsec_ready = false
+        local ok_req, cs = pcall(require, "crowdsec")
+        if not ok_req then
+            ngx.log(ngx.ERR, "[CrowdSec] Failed to load module")
+            return
+        end
         local ok, err = cs.init("/etc/crowdsec/bouncers/crowdsec-openresty-bouncer.conf", "crowdsec-openresty-bouncer/v1.1.1")
         if ok == nil then
             ngx.log(ngx.ERR, "[CrowdSec] " .. err)
@@ -76,11 +81,13 @@ http {
             ngx.log(ngx.ALERT, "[CrowdSec] Bouncer disabled")
         else
             ngx.log(ngx.ALERT, "[CrowdSec] Bouncer initialized")
+            crowdsec_ready = true
         end
     }
 
     init_worker_by_lua_block {
-        cs = require "crowdsec"
+        if not crowdsec_ready then return end
+        local cs = require "crowdsec"
         local mode = cs.get_mode()
         if string.lower(mode) == "stream" then
             cs.SetupStream()
@@ -148,6 +155,7 @@ http {
 
             # CrowdSec : verifier si l'IP est bannie
             access_by_lua_block {
+                if not crowdsec_ready then return end
                 local cs = require "crowdsec"
                 cs.Allow(ngx.var.remote_addr)
             }


### PR DESCRIPTION
- Fix health check protocol: https → http in container.ts
- Start Nginx immediately instead of waiting for CrowdSec LAPI
- Make CrowdSec bouncer gracefully degrade if LAPI is not ready
- CrowdSec starts in background, bouncer activates when ready