### PR TITLE
fix: ensure HOSTNAME is set for Node.js in entrypoint

### DIFF
--- a/infrastructure/nginx/entrypoint.sh
+++ b/infrastructure/nginx/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+export HOSTNAME="${HOSTNAME:-0.0.0.0}"
+export PORT=3000
+
 node server.js &
 NODE_PID=$!
 


### PR DESCRIPTION
The shell might override the HOSTNAME env var with the container's hostname. Explicitly export it with a fallback to 0.0.0.0 so Node.js listens on all interfaces.