### PR TITLE
fix: fix realip extraction for Scaleway proxy chain

### DIFF
--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -13,13 +13,13 @@ http {
     server_tokens off;
 
     # Extraction de l'IP client reelle depuis X-Forwarded-For
-    # Le container serverless Scaleway est toujours derriere un unique proxy
-    # Scaleway, seul a pouvoir atteindre le container. On fait confiance a
-    # $remote_addr (toujours une IP Scaleway) pour extraire la derniere IP
-    # du header X-Forwarded-For, qui est l'IP client ajoutee par Scaleway.
-    set_real_ip_from 0.0.0.0/0;
-    set_real_ip_from ::/0;
+    # Scaleway utilise plusieurs proxys internes (100.96.x.x dans la plage CGNAT
+    # 100.64.0.0/10). real_ip_recursive remonte la chaine XFF de droite a gauche
+    # en supprimant les IPs de confiance jusqu'a trouver l'IP client reelle.
+    set_real_ip_from 100.64.0.0/10;
+    set_real_ip_from 169.254.0.0/16;
     real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
 
     # GeoIP2 utilise $remote_addr (reecrit par realip) par defaut
     geoip2 /usr/share/GeoIP/dbip-country-lite.mmdb {


### PR DESCRIPTION
Scaleway routes through multiple internal proxies (100.96.x.x in CGNAT range 100.64.0.0/10 and 169.254.x.x link-local). The previous config (set_real_ip_from 0.0.0.0/0) took the last XFF IP which was always a Scaleway internal IP, causing GeoIP to resolve XX.

Now uses real_ip_recursive to walk the XFF chain right-to-left, stripping trusted Scaleway IPs until the real client IP is found.