### PR TITLE
fix: trust all private/reserved IP ranges for realip

### DIFF
--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -13,11 +13,17 @@ http {
     server_tokens off;
 
     # Extraction de l'IP client reelle depuis X-Forwarded-For
-    # Scaleway utilise plusieurs proxys internes (100.96.x.x dans la plage CGNAT
-    # 100.64.0.0/10). real_ip_recursive remonte la chaine XFF de droite a gauche
-    # en supprimant les IPs de confiance jusqu'a trouver l'IP client reelle.
+    # real_ip_recursive remonte la chaine XFF de droite a gauche en supprimant
+    # les IPs privees/reservees (proxys internes) jusqu'a l'IP client reelle.
+    set_real_ip_from 10.0.0.0/8;
+    set_real_ip_from 172.16.0.0/12;
+    set_real_ip_from 192.168.0.0/16;
     set_real_ip_from 100.64.0.0/10;
+    set_real_ip_from 127.0.0.0/8;
     set_real_ip_from 169.254.0.0/16;
+    set_real_ip_from ::1/128;
+    set_real_ip_from fc00::/7;
+    set_real_ip_from fe80::/10;
     real_ip_header X-Forwarded-For;
     real_ip_recursive on;
 


### PR DESCRIPTION
Use the complete set of non-routable IP ranges (RFC 1918, CGNAT, loopback, link-local + IPv6 equivalents) as trusted proxies. This is the standard approach for cloud infrastructure where internal proxy IPs are dynamic and unpredictable.