### PR TITLE
perf: add bot rate limiting and scale up infrastructure

### DIFF
--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -143,6 +143,19 @@ http {
     limit_req_zone $binary_remote_addr zone=global:10m rate=10r/s;
     limit_req_status 429;
 
+    # Rate limiting bots : 1 requete/seconde par bot (toutes IPs confondues)
+    map $http_user_agent $is_bot {
+        default "";
+        "~*bingbot"     "bingbot";
+        "~*googlebot"   "googlebot";
+        "~*yandexbot"   "yandexbot";
+        "~*ahrefsbot"   "ahrefsbot";
+        "~*semrushbot"  "semrushbot";
+        "~*dotbot"      "dotbot";
+        "~*mj12bot"     "mj12bot";
+    }
+    limit_req_zone $is_bot zone=bots:1m rate=1r/s;
+
     proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=app_cache:10m max_size=256m inactive=6h use_temp_path=off;
 
     server {
@@ -174,6 +187,7 @@ http {
                 cs.Allow(ngx.var.remote_addr)
             }
 
+            limit_req zone=bots burst=3 nodelay;
             limit_req zone=global burst=20 nodelay;
 
             proxy_pass http://nextjs;

--- a/infrastructure/src/resources/container.ts
+++ b/infrastructure/src/resources/container.ts
@@ -22,10 +22,10 @@ const container = new containers.Container(
     tags: config.tags,
     namespaceId: namespace.id,
     registryImage: APP_IMAGE_NAME,
-    cpuLimit: 1120,
-    memoryLimit: 2048,
+    cpuLimit: 2240,
+    memoryLimit: 4096,
     minScale: 1,
-    maxScale: 3,
+    maxScale: 5,
     port: 80,
     protocol: 'http1',
     environmentVariables: {

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -8,7 +8,8 @@ export default {
   changefreq: 'monthly',
   robotsTxtOptions: {
     policies: [
-      { userAgent: '*', allow: '/', disallow: ['/api/'] },
+      { userAgent: '*', allow: '/', disallow: ['/api/', '/*?*'] },
+      { userAgent: 'bingbot', crawlDelay: 2 },
       { userAgent: 'GPTBot', disallow: '/' },
       { userAgent: 'ChatGPT-User', disallow: '/' },
       { userAgent: 'Google-Extended', disallow: '/' },


### PR DESCRIPTION
- nginx: add per-User-Agent rate limit (1r/s per bot, all IPs combined) targeting Bingbot, Googlebot, Yandex, Ahrefs, Semrush, Dotbot, MJ12
- robots.txt: disallow URLs with query params (no SEO value for filtered pages) and add Crawl-delay: 2 for Bingbot
- infra: scale CPU from 1120 to 2240 mCPU, RAM from 2048 to 4096 MB, maxScale from 3 to 5 containers

Bingbot was the primary cause of CPU saturation, sending ~100 req/s across dozens of IPs, bypassing the per-IP rate limit.