### PR TITLE
fix: reduce SSR payload size and rate limit Facebook bot

### DIFF
--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -153,6 +153,8 @@ http {
         "~*semrushbot"  "semrushbot";
         "~*dotbot"      "dotbot";
         "~*mj12bot"     "mj12bot";
+        "~*facebookexternalhit" "facebookexternalhit";
+        "~*meta-externalagent"  "meta-externalagent";
     }
     limit_req_zone $is_bot zone=bots:1m rate=1r/s;
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,14 +16,6 @@ const nextConfig: NextConfig = {
           { key: 'Access-Control-Allow-Headers', value: 'Content-Type' }
         ]
       },
-      {
-        source: '/api/stats/:path*',
-        headers: [{ key: 'Cache-Control', value: 'public, max-age=21600, s-maxage=21600' }]
-      },
-      {
-        source: '/api/lieux/:path*',
-        headers: [{ key: 'Cache-Control', value: 'public, max-age=3600, s-maxage=21600' }]
-      }
     ];
   },
   async redirects() {

--- a/src/app/(main)/(full-page)/(regions)/[region]/[departement]/lieux/[id]/page.tsx
+++ b/src/app/(main)/(full-page)/(regions)/[region]/[departement]/lieux/[id]/page.tsx
@@ -24,7 +24,11 @@ export const generateMetadata = async ({ params }: PageProps): Promise<Metadata>
 
 export default pageBuilder()
   .use(withRegion(), withDepartement(), withParams('id'), withUrlSearchParams())
-  .use(withFetch('lieu', ({ id }) => fetchLieuDetails(id)))
+  .use(
+    withFetch('lieu', ({ id }) => fetchLieuDetails(id), {
+      cache: { cacheKey: ({ id }) => ['lieu', id], revalidate: false, tags: ['lieux'] }
+    })
+  )
   .use(withRequired('lieu'))
   .render(async ({ region, departement, lieu, urlSearchParams }) => {
     const siteUrl = process.env['NEXT_PUBLIC_SITE_URL'];

--- a/src/app/(main)/(full-page)/(regions)/[region]/[departement]/lieux/page.tsx
+++ b/src/app/(main)/(full-page)/(regions)/[region]/[departement]/lieux/page.tsx
@@ -45,8 +45,16 @@ export default pageBuilder()
   .use(withRegion(), withDepartement(), withSearchParams(filtersSchema), withUrlSearchParams())
   .use(withPagination(pageSchema))
   .use(
-    withFetch('lieuxData', ({ departement, searchParams, page }) =>
-      fetchLieux(departement)(searchParams, { page, limit: PAGE_SIZE })
+    withFetch(
+      'lieuxData',
+      ({ departement, searchParams, page }) => fetchLieux(departement)(searchParams, { page, limit: PAGE_SIZE }),
+      {
+        cache: {
+          cacheKey: ({ departement, searchParams, page }) => ['lieuxData', departement.code, searchParams, page],
+          revalidate: false,
+          tags: ['lieux']
+        }
+      }
     )
   )
   .render(async ({ region, departement, lieuxData: { lieux, total }, page, urlSearchParams }) => (

--- a/src/app/(main)/(full-page)/(regions)/[region]/[departement]/lieux/page.tsx
+++ b/src/app/(main)/(full-page)/(regions)/[region]/[departement]/lieux/page.tsx
@@ -50,7 +50,14 @@ export default pageBuilder()
       ({ departement, searchParams, page }) => fetchLieux(departement)(searchParams, { page, limit: PAGE_SIZE }),
       {
         cache: {
-          cacheKey: ({ departement, searchParams, page }) => ['lieuxData', departement.code, searchParams, page],
+          cacheKey: ({ departement, searchParams, page }) => [
+            'lieuxData',
+            'departement',
+            departement.code,
+            searchParams,
+            page,
+            PAGE_SIZE
+          ],
           revalidate: false,
           tags: ['lieux']
         }

--- a/src/app/(main)/(full-page)/(regions)/[region]/lieux/page.tsx
+++ b/src/app/(main)/(full-page)/(regions)/[region]/lieux/page.tsx
@@ -36,7 +36,7 @@ export default pageBuilder()
   .use(
     withFetch('lieuxData', ({ region, searchParams, page }) => fetchLieux(region)(searchParams, { page, limit: PAGE_SIZE }), {
       cache: {
-        cacheKey: ({ region, searchParams, page }) => ['lieuxData', region.code, searchParams, page],
+        cacheKey: ({ region, searchParams, page }) => ['lieuxData', 'region', region.code, searchParams, page, PAGE_SIZE],
         revalidate: false,
         tags: ['lieux']
       }

--- a/src/app/(main)/(full-page)/(regions)/[region]/lieux/page.tsx
+++ b/src/app/(main)/(full-page)/(regions)/[region]/lieux/page.tsx
@@ -33,7 +33,15 @@ export const generateMetadata = async ({ params }: PageProps): Promise<Metadata>
 export default pageBuilder()
   .use(withRegion(), withSearchParams(filtersSchema), withUrlSearchParams())
   .use(withPagination(pageSchema))
-  .use(withFetch('lieuxData', ({ region, searchParams, page }) => fetchLieux(region)(searchParams, { page, limit: PAGE_SIZE })))
+  .use(
+    withFetch('lieuxData', ({ region, searchParams, page }) => fetchLieux(region)(searchParams, { page, limit: PAGE_SIZE }), {
+      cache: {
+        cacheKey: ({ region, searchParams, page }) => ['lieuxData', region.code, searchParams, page],
+        revalidate: false,
+        tags: ['lieux']
+      }
+    })
+  )
   .render(async ({ region, lieuxData: { lieux, total }, page, urlSearchParams }) => (
     <LieuxPage
       totalLieux={total}

--- a/src/app/(main)/(full-page)/(regions)/lieux/[id]/page.tsx
+++ b/src/app/(main)/(full-page)/(regions)/lieux/[id]/page.tsx
@@ -11,7 +11,11 @@ import { pageBuilder, withDerive, withFetch, withParams, withRequired, withUrlSe
 
 export default pageBuilder()
   .use(withParams('id'), withUrlSearchParams())
-  .use(withFetch('lieu', ({ id }) => fetchLieuById(id)))
+  .use(
+    withFetch('lieu', ({ id }) => fetchLieuById(id), {
+      cache: { cacheKey: ({ id }) => ['lieu-redirect', id], revalidate: false, tags: ['lieux'] }
+    })
+  )
   .use(withRequired('lieu'))
   .use(withDerive('code', ({ lieu }) => getDepartementCodeFromInsee(lieu.adresse.code_insee)))
   .use(

--- a/src/app/(main)/(full-page)/(regions)/lieux/page.tsx
+++ b/src/app/(main)/(full-page)/(regions)/lieux/page.tsx
@@ -20,7 +20,11 @@ export default pageBuilder()
   .use(withPagination(pageSchema))
   .use(
     withFetch('lieuxData', ({ searchParams, page }) => fetchLieux()(searchParams, { page, limit: PAGE_SIZE }), {
-      cache: { cacheKey: ({ searchParams, page }) => ['lieuxData', searchParams, page], revalidate: false, tags: ['lieux'] }
+      cache: {
+        cacheKey: ({ searchParams, page }) => ['lieuxData', searchParams, page, PAGE_SIZE],
+        revalidate: false,
+        tags: ['lieux']
+      }
     })
   )
   .render(async ({ lieuxData: { lieux, total }, page, urlSearchParams }) => (

--- a/src/app/(main)/(full-page)/(regions)/lieux/page.tsx
+++ b/src/app/(main)/(full-page)/(regions)/lieux/page.tsx
@@ -18,7 +18,11 @@ const PAGE_SIZE = 24;
 export default pageBuilder()
   .use(withSearchParams(filtersSchema), withUrlSearchParams())
   .use(withPagination(pageSchema))
-  .use(withFetch('lieuxData', ({ searchParams, page }) => fetchLieux()(searchParams, { page, limit: PAGE_SIZE })))
+  .use(
+    withFetch('lieuxData', ({ searchParams, page }) => fetchLieux()(searchParams, { page, limit: PAGE_SIZE }), {
+      cache: { cacheKey: ({ searchParams, page }) => ['lieuxData', searchParams, page], revalidate: false, tags: ['lieux'] }
+    })
+  )
   .render(async ({ lieuxData: { lieux, total }, page, urlSearchParams }) => (
     <LieuxPage
       totalLieux={total}

--- a/src/app/(main)/(with-map)/(regions)/[region]/[departement]/page.tsx
+++ b/src/app/(main)/(with-map)/(regions)/[region]/[departement]/page.tsx
@@ -49,7 +49,14 @@ export default pageBuilder()
       ({ departement, searchParams, page }) => fetchLieux(departement)(searchParams, { page, limit: PAGE_SIZE }),
       {
         cache: {
-          cacheKey: ({ departement, searchParams, page }) => ['lieuxData', departement.code, searchParams, page],
+          cacheKey: ({ departement, searchParams, page }) => [
+            'lieuxData',
+            'departement',
+            departement.code,
+            searchParams,
+            page,
+            PAGE_SIZE
+          ],
           revalidate: false,
           tags: ['lieux']
         }

--- a/src/app/(main)/(with-map)/(regions)/[region]/[departement]/page.tsx
+++ b/src/app/(main)/(with-map)/(regions)/[region]/[departement]/page.tsx
@@ -44,8 +44,16 @@ export default pageBuilder()
   .use(withRegion(), withDepartement(), withSearchParams(filtersSchema))
   .use(withPagination(pageSchema))
   .use(
-    withFetch('lieuxData', ({ departement, searchParams, page }) =>
-      fetchLieux(departement)(searchParams, { page, limit: PAGE_SIZE })
+    withFetch(
+      'lieuxData',
+      ({ departement, searchParams, page }) => fetchLieux(departement)(searchParams, { page, limit: PAGE_SIZE }),
+      {
+        cache: {
+          cacheKey: ({ departement, searchParams, page }) => ['lieuxData', departement.code, searchParams, page],
+          revalidate: false,
+          tags: ['lieux']
+        }
+      }
     )
   )
   .render(async ({ region, departement, lieuxData: { lieux, total }, page }) => (

--- a/src/app/(main)/(with-map)/(regions)/[region]/page.tsx
+++ b/src/app/(main)/(with-map)/(regions)/[region]/page.tsx
@@ -34,7 +34,13 @@ export const generateMetadata = async ({ params }: PageProps): Promise<Metadata>
 export default pageBuilder()
   .use(withRegion(), withSearchParams(filtersSchema))
   .use(
-    withFetch('totalLieux', ({ region, searchParams }) => countLieux(region)(searchParams)),
+    withFetch('totalLieux', ({ region, searchParams }) => countLieux(region)(searchParams), {
+      cache: {
+        cacheKey: ({ region, searchParams }) => ['totalLieux', region.code, searchParams],
+        revalidate: false,
+        tags: ['lieux']
+      }
+    }),
     withFetch('departements', ({ region, searchParams }) =>
       Promise.resolve(filterDepartementsByTerritoire(searchParams).filter(matchingDepartementsFrom(region)))
     )

--- a/src/app/(main)/(with-map)/(regions)/page.tsx
+++ b/src/app/(main)/(with-map)/(regions)/page.tsx
@@ -7,7 +7,9 @@ import { pageBuilder, withDerive, withFetch, withSearchParams } from '@/librarie
 export default pageBuilder()
   .use(withSearchParams(filtersSchema))
   .use(
-    withFetch('totalLieux', ({ searchParams }) => countLieux()(searchParams)),
+    withFetch('totalLieux', ({ searchParams }) => countLieux()(searchParams), {
+      cache: { cacheKey: ({ searchParams }) => ['totalLieux', searchParams], revalidate: false, tags: ['lieux'] }
+    }),
     withDerive('regions', ({ searchParams }) => filterRegionsByTerritoire(searchParams))
   )
   .render(async ({ totalLieux, regions }) => <RegionsPage totalLieux={totalLieux} regions={regions} />);

--- a/src/app/(main)/(with-map)/layout.tsx
+++ b/src/app/(main)/(with-map)/layout.tsx
@@ -3,13 +3,11 @@ import { filtersSchema } from '@/libraries/inclusion-numerique-api';
 import { layoutBuilder, withFetch, withSearchParamsFromHeaders } from '@/libraries/nextjs/layout';
 import ClientLayout from './client.layout';
 
-const SIX_HOURS = 6 * 60 * 60;
-
 export default layoutBuilder()
   .use(withSearchParamsFromHeaders(filtersSchema))
   .use(
     withFetch('stats', ({ searchParams }) => fetchAllStats(searchParams), {
-      cache: { cacheKey: ({ searchParams }) => ['stats', searchParams], revalidate: SIX_HOURS }
+      cache: { cacheKey: ({ searchParams }) => ['stats', searchParams], revalidate: false, tags: ['lieux'] }
     })
   )
   .render(({ stats: { regions, departements } }, children) => (

--- a/src/app/api/cache/reset/route.ts
+++ b/src/app/api/cache/reset/route.ts
@@ -1,3 +1,4 @@
+import { revalidateTag } from 'next/cache';
 import { serverEnv } from '@/env.server';
 import { invalidateCache } from '@/libraries/lieux-cache';
 import { routeBuilder, withStaticBearerAuth } from '@/libraries/nextjs/route';
@@ -6,5 +7,6 @@ export const POST = routeBuilder()
   .use(withStaticBearerAuth(serverEnv.CACHE_RESET_TOKEN))
   .handle(async () => {
     invalidateCache();
+    revalidateTag('lieux', { expire: 0 });
     return Response.json({ status: 'cache reset initiated' });
   });

--- a/src/app/api/lieux/[id]/route.ts
+++ b/src/app/api/lieux/[id]/route.ts
@@ -3,14 +3,12 @@ import { fetchLieuDetails } from '@/features/lieux-inclusion-numerique/abilities
 import { toLieuDetails } from '@/libraries/inclusion-numerique-api/transfer/to-lieu-details';
 import { routeBuilder, withFetch, withPathParams, withRequired } from '@/libraries/nextjs/route';
 
-const SIX_HOURS = 6 * 60 * 60;
-
 export const GET = routeBuilder()
   .use(withPathParams('id'))
   .use(withRequired('id'))
   .use(
     withFetch('lieu', ({ id }) => fetchLieuDetails(id), {
-      cache: { cacheKey: ({ id }) => ['lieu', id], revalidate: SIX_HOURS }
+      cache: { cacheKey: ({ id }) => ['lieu', id], revalidate: false, tags: ['lieux'] }
     })
   )
   .use(withRequired('lieu'))

--- a/src/app/api/lieux/chunk/route.ts
+++ b/src/app/api/lieux/chunk/route.ts
@@ -3,8 +3,6 @@ import { fetchLieuxForChunkServer } from '@/features/lieux-inclusion-numerique/a
 import { filtersSchema } from '@/libraries/inclusion-numerique-api';
 import { routeBuilder, withFetch, withSearchParams } from '@/libraries/nextjs/route';
 
-const SIX_HOURS = 6 * 60 * 60;
-
 const locationSchema = z.object({
   latitude: z.transform(Number).refine((latitude: number) => !Number.isNaN(latitude), {
     message: 'le paramètre latitude est requis et dois être un nombre, ex : ?latitude=42.1337'
@@ -20,7 +18,7 @@ export const GET = routeBuilder()
     withFetch(
       'lieux',
       ({ searchParams: { latitude, longitude, ...filters } }) => fetchLieuxForChunkServer([longitude, latitude], filters),
-      { cache: { cacheKey: ({ searchParams }) => ['chunk', searchParams], revalidate: SIX_HOURS } }
+      { cache: { cacheKey: ({ searchParams }) => ['chunk', searchParams], revalidate: false, tags: ['lieux'] } }
     )
   )
   .handle(async ({ lieux }) => Response.json(lieux));

--- a/src/app/api/lieux/departement/[code]/route.ts
+++ b/src/app/api/lieux/departement/[code]/route.ts
@@ -6,7 +6,6 @@ import { toLieuListItem } from '@/libraries/inclusion-numerique-api/transfer/to-
 import { routeBuilder, withDerive, withFetch, withPathParams, withRequired, withSearchParams } from '@/libraries/nextjs/route';
 
 const PAGE_SIZE = 10;
-const SIX_HOURS = 6 * 60 * 60;
 
 export const GET = routeBuilder()
   .use(withPathParams('code'), withSearchParams(paginationSchema(PAGE_SIZE).extend(filtersSchema.shape)))
@@ -17,7 +16,11 @@ export const GET = routeBuilder()
       'lieuxData',
       ({ departement, searchParams: { page, limit, ...filters } }) => fetchLieux(departement)(filters, { page, limit }),
       {
-        cache: { cacheKey: ({ departement, searchParams }) => ['lieux', departement.code, searchParams], revalidate: SIX_HOURS }
+        cache: {
+          cacheKey: ({ departement, searchParams }) => ['lieux', 'departement', departement.code, searchParams],
+          revalidate: false,
+          tags: ['lieux']
+        }
       }
     )
   )

--- a/src/app/api/lieux/region/[slug]/route.ts
+++ b/src/app/api/lieux/region/[slug]/route.ts
@@ -6,7 +6,6 @@ import { toLieuListItem } from '@/libraries/inclusion-numerique-api/transfer/to-
 import { routeBuilder, withFetch, withSearchParams } from '@/libraries/nextjs/route';
 
 const PAGE_SIZE = 24;
-const SIX_HOURS = 6 * 60 * 60;
 
 export const GET = routeBuilder()
   .use(withRegion('slug'), withSearchParams(paginationSchema(PAGE_SIZE).extend(filtersSchema.shape)))
@@ -14,7 +13,13 @@ export const GET = routeBuilder()
     withFetch(
       'lieuxData',
       ({ region, searchParams: { page, limit, ...filters } }) => fetchLieux(region)(filters, { page, limit }),
-      { cache: { cacheKey: ({ region, searchParams }) => ['lieux', region.code, searchParams], revalidate: SIX_HOURS } }
+      {
+        cache: {
+          cacheKey: ({ region, searchParams }) => ['lieux', 'region', region.code, searchParams],
+          revalidate: false,
+          tags: ['lieux']
+        }
+      }
     )
   )
   .handle(async ({ lieuxData: { lieux, total } }) =>

--- a/src/app/api/lieux/route.ts
+++ b/src/app/api/lieux/route.ts
@@ -5,13 +5,12 @@ import { toLieuListItem } from '@/libraries/inclusion-numerique-api/transfer/to-
 import { routeBuilder, withFetch, withSearchParams } from '@/libraries/nextjs/route';
 
 const PAGE_SIZE = 24;
-const SIX_HOURS = 6 * 60 * 60;
 
 export const GET = routeBuilder()
   .use(withSearchParams(paginationSchema(PAGE_SIZE).extend(filtersSchema.shape)))
   .use(
     withFetch('lieuxData', ({ searchParams: { page, limit, ...filters } }) => fetchLieux()(filters, { page, limit }), {
-      cache: { cacheKey: ({ searchParams }) => ['lieux', searchParams], revalidate: SIX_HOURS }
+      cache: { cacheKey: ({ searchParams }) => ['lieux', searchParams], revalidate: false, tags: ['lieux'] }
     })
   )
   .handle(async ({ lieuxData: { lieux, total } }) =>

--- a/src/app/api/lieux/search/route.ts
+++ b/src/app/api/lieux/search/route.ts
@@ -2,8 +2,6 @@ import { z } from 'zod';
 import { searchLieuxByName } from '@/features/lieux-inclusion-numerique/abilities/map-view/query/search-lieux-by-name.server';
 import { routeBuilder, withFetch, withSearchParams } from '@/libraries/nextjs/route';
 
-const SIX_HOURS = 6 * 60 * 60;
-
 const searchSchema = z.object({
   q: z.string().min(1).max(100)
 });
@@ -12,7 +10,7 @@ export const GET = routeBuilder()
   .use(withSearchParams(searchSchema))
   .use(
     withFetch('lieux', ({ searchParams }) => searchLieuxByName(searchParams.q), {
-      cache: { cacheKey: ({ searchParams }) => ['search', searchParams.q], revalidate: SIX_HOURS }
+      cache: { cacheKey: ({ searchParams }) => ['search', searchParams.q], revalidate: false, tags: ['lieux'] }
     })
   )
   .handle(async ({ lieux }) => Response.json(lieux));

--- a/src/app/api/stats/departements/route.ts
+++ b/src/app/api/stats/departements/route.ts
@@ -2,13 +2,11 @@ import { fetchDepartementsStats } from '@/features/collectivites-territoriales/a
 import { filtersSchema } from '@/libraries/inclusion-numerique-api';
 import { routeBuilder, withFetch, withSearchParams } from '@/libraries/nextjs/route';
 
-const SIX_HOURS = 6 * 60 * 60;
-
 export const GET = routeBuilder()
   .use(withSearchParams(filtersSchema))
   .use(
     withFetch('departementsStats', ({ searchParams }) => fetchDepartementsStats(searchParams), {
-      cache: { cacheKey: ({ searchParams }) => ['departements', searchParams], revalidate: SIX_HOURS }
+      cache: { cacheKey: ({ searchParams }) => ['departements', searchParams], revalidate: false, tags: ['lieux'] }
     })
   )
   .handle(async ({ departementsStats }) => Response.json(departementsStats));

--- a/src/app/api/stats/regions/[slug]/route.ts
+++ b/src/app/api/stats/regions/[slug]/route.ts
@@ -3,13 +3,15 @@ import { countLieux } from '@/features/lieux-inclusion-numerique/abilities/count
 import { filtersSchema } from '@/libraries/inclusion-numerique-api';
 import { routeBuilder, withFetch, withSearchParams } from '@/libraries/nextjs/route';
 
-const SIX_HOURS = 6 * 60 * 60;
-
 export const GET = routeBuilder()
   .use(withRegion('slug'), withSearchParams(filtersSchema))
   .use(
     withFetch('totalLieux', ({ region, searchParams }) => countLieux(region)(searchParams), {
-      cache: { cacheKey: ({ region, searchParams }) => ['region', region.code, searchParams], revalidate: SIX_HOURS }
+      cache: {
+        cacheKey: ({ region, searchParams }) => ['region', region.code, searchParams],
+        revalidate: false,
+        tags: ['lieux']
+      }
     })
   )
   .handle(async ({ totalLieux }) => Response.json({ totalLieux }));

--- a/src/app/api/stats/regions/route.ts
+++ b/src/app/api/stats/regions/route.ts
@@ -2,13 +2,11 @@ import { fetchRegionsStats } from '@/features/collectivites-territoriales/abilit
 import { filtersSchema } from '@/libraries/inclusion-numerique-api';
 import { routeBuilder, withFetch, withSearchParams } from '@/libraries/nextjs/route';
 
-const SIX_HOURS = 6 * 60 * 60;
-
 export const GET = routeBuilder()
   .use(withSearchParams(filtersSchema))
   .use(
     withFetch('regionsStats', ({ searchParams }) => fetchRegionsStats(searchParams), {
-      cache: { cacheKey: ({ searchParams }) => ['regions', searchParams], revalidate: SIX_HOURS }
+      cache: { cacheKey: ({ searchParams }) => ['regions', searchParams], revalidate: false, tags: ['lieux'] }
     })
   )
   .handle(async ({ regionsStats }) => Response.json(regionsStats));

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -2,13 +2,11 @@ import { fetchAllStats } from '@/features/collectivites-territoriales/abilities/
 import { filtersSchema } from '@/libraries/inclusion-numerique-api';
 import { routeBuilder, withFetch, withSearchParams } from '@/libraries/nextjs/route';
 
-const SIX_HOURS = 6 * 60 * 60;
-
 export const GET = routeBuilder()
   .use(withSearchParams(filtersSchema))
   .use(
     withFetch('stats', ({ searchParams }) => fetchAllStats(searchParams), {
-      cache: { cacheKey: ({ searchParams }) => ['stats', searchParams], revalidate: SIX_HOURS }
+      cache: { cacheKey: ({ searchParams }) => ['stats', searchParams], revalidate: false, tags: ['lieux'] }
     })
   )
   .handle(async ({ stats }) => Response.json(stats));

--- a/src/app/api/stats/total/route.ts
+++ b/src/app/api/stats/total/route.ts
@@ -2,13 +2,11 @@ import { countLieux } from '@/features/lieux-inclusion-numerique/abilities/count
 import { filtersSchema } from '@/libraries/inclusion-numerique-api';
 import { routeBuilder, withFetch, withSearchParams } from '@/libraries/nextjs/route';
 
-const SIX_HOURS = 6 * 60 * 60;
-
 export const GET = routeBuilder()
   .use(withSearchParams(filtersSchema))
   .use(
     withFetch('totalLieux', ({ searchParams }) => countLieux()(searchParams), {
-      cache: { cacheKey: ({ searchParams }) => ['total', searchParams], revalidate: SIX_HOURS }
+      cache: { cacheKey: ({ searchParams }) => ['total', searchParams], revalidate: false, tags: ['lieux'] }
     })
   )
   .handle(async ({ totalLieux }) => Response.json({ totalLieux }));

--- a/src/features/lieux-inclusion-numerique/abilities/list-view/query/fetch-lieux.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/list-view/query/fetch-lieux.ts
@@ -1,4 +1,9 @@
-import type { Collectivite, FiltersSchema, LieuxRouteResponse } from '@/libraries/inclusion-numerique-api';
+import {
+  type Collectivite,
+  type FiltersSchema,
+  LIEU_LIST_FIELDS,
+  type LieuxRouteResponse
+} from '@/libraries/inclusion-numerique-api';
 import { filterLieux, getAllLieux } from '@/libraries/lieux-cache';
 
 type PaginationParams = {
@@ -11,10 +16,13 @@ export type LieuxWithTotal = {
   total: number;
 };
 
+const pick = (lieu: LieuxRouteResponse[number]): LieuxRouteResponse[number] =>
+  Object.fromEntries(LIEU_LIST_FIELDS.map((key) => [key, lieu[key]])) as LieuxRouteResponse[number];
+
 export const fetchLieux =
   (collectivite?: Collectivite) =>
   async (filters: FiltersSchema, { page, limit }: PaginationParams): Promise<LieuxWithTotal> => {
     const allLieux = await getAllLieux();
     const filtered = filterLieux(allLieux, filters, collectivite);
-    return { lieux: filtered.slice((page - 1) * limit, page * limit), total: filtered.length };
+    return { lieux: filtered.slice((page - 1) * limit, page * limit).map(pick), total: filtered.length };
   };

--- a/src/features/lieux-inclusion-numerique/abilities/map-view/query/fetch-lieux-for-chunk.server.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/map-view/query/fetch-lieux-for-chunk.server.ts
@@ -7,13 +7,15 @@ export const fetchLieuxForChunkServer = async (position: Position2D, filters: Fi
   const [minLon, minLat, maxLon, maxLat]: BBox = mapChunk(position, MAP_CHUNK_OPTIONS);
   const allLieux = await getAllLieux();
 
-  return filterLieux(allLieux, filters).filter(
-    (lieu) =>
-      lieu.latitude != null &&
-      lieu.longitude != null &&
-      lieu.latitude > minLat &&
-      lieu.latitude <= maxLat &&
-      lieu.longitude > minLon &&
-      lieu.longitude <= maxLon
-  );
+  return filterLieux(allLieux, filters)
+    .filter(
+      (lieu) =>
+        lieu.latitude != null &&
+        lieu.longitude != null &&
+        lieu.latitude > minLat &&
+        lieu.latitude <= maxLat &&
+        lieu.longitude > minLon &&
+        lieu.longitude <= maxLon
+    )
+    .map(({ id, nom, latitude, longitude }) => ({ id, nom, latitude, longitude }));
 };

--- a/src/features/lieux-inclusion-numerique/abilities/map-view/query/search-lieux-by-name.server.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/map-view/query/search-lieux-by-name.server.ts
@@ -3,5 +3,8 @@ import { getAllLieux } from '@/libraries/lieux-cache';
 export const searchLieuxByName = async (query: string) => {
   const allLieux = await getAllLieux();
   const lowerQuery = query.toLowerCase();
-  return allLieux.filter((lieu) => lieu.nom.toLowerCase().includes(lowerQuery)).slice(0, 10);
+  return allLieux
+    .filter((lieu) => lieu.nom.toLowerCase().includes(lowerQuery))
+    .slice(0, 10)
+    .map(({ id, nom, latitude, longitude, adresse }) => ({ id, nom, latitude, longitude, adresse }));
 };

--- a/src/libraries/nextjs/cache/cached.ts
+++ b/src/libraries/nextjs/cache/cached.ts
@@ -3,5 +3,5 @@ import { unstable_cache } from 'next/cache';
 export const cached = <TArgs extends unknown[], TResult>(
   fn: (...args: TArgs) => Promise<TResult>,
   keyParts: string[],
-  options: { revalidate: number }
-) => unstable_cache(fn, keyParts, { revalidate: options.revalidate });
+  options: { revalidate: number | false; tags?: string[] }
+) => unstable_cache(fn, keyParts, { revalidate: options.revalidate, ...(options.tags ? { tags: options.tags } : {}) });

--- a/src/libraries/nextjs/shared/middlewares/with-fetch.ts
+++ b/src/libraries/nextjs/shared/middlewares/with-fetch.ts
@@ -2,11 +2,12 @@ import { cached } from '../../cache';
 
 type CacheOptions<TContext> = {
   cacheKey: (ctx: TContext) => unknown[];
-  revalidate: number;
+  revalidate: number | false;
+  tags?: string[];
 };
 
 const withCache = async (
-  cache: { cacheKey: (ctx: unknown) => unknown[]; revalidate: number },
+  cache: { cacheKey: (ctx: unknown) => unknown[]; revalidate: number | false; tags?: string[] },
   ctx: Record<string, unknown>,
   // biome-ignore lint/complexity/noBannedTypes: implementation signature needs generic callable
   fetcher: Function,
@@ -15,7 +16,7 @@ const withCache = async (
   const cachedFetcher = cached(
     () => fetcher(ctx),
     cache.cacheKey(ctx).map((k) => (typeof k === 'string' ? k : JSON.stringify(k))),
-    { revalidate: cache.revalidate }
+    { revalidate: cache.revalidate, ...(cache.tags ? { tags: cache.tags } : {}) }
   );
   return { ctx: { [key]: await cachedFetcher() } };
 };
@@ -30,7 +31,7 @@ export function withFetch(
   key: string,
   // biome-ignore lint/complexity/noBannedTypes: implementation signature needs generic callable
   fetcher: Function,
-  options?: { cache?: { cacheKey: (ctx: unknown) => unknown[]; revalidate: number } }
+  options?: { cache?: { cacheKey: (ctx: unknown) => unknown[]; revalidate: number | false; tags?: string[] } }
 ) {
   return async (ctx: Record<string, unknown>, _extra: unknown) =>
     options?.cache ? await withCache(options.cache, ctx, fetcher, key) : { ctx: { [key]: await fetcher(ctx) } };


### PR DESCRIPTION
The BFF cache was returning all fields per lieu (~30) instead of only the fields each caller needs. This caused SSR responses to grow from ~80-100KB to ~240-330KB (3x), increasing CPU usage per request and causing periodic Node.js crashes under bot traffic.

- fetchLieux: select only LIEU_LIST_FIELDS (10 fields)
- fetchLieuxForChunkServer: select only id, nom, latitude, longitude
- searchLieuxByName: select only id, nom, latitude, longitude, adresse
- nginx: add facebookexternalhit and meta-externalagent to bot rate limiting (Facebook was sending 534 req/10min unthrottled)