### PR TITLE
perf: render LCP heading without waiting for map loading state

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,7 +7,11 @@ const nextConfig: NextConfig = {
   basePath: process.env.NEXT_PUBLIC_BASE_PATH,
   assetPrefix: process.env.NEXT_ASSET_PREFIX,
   async headers() {
+    const assetPrefix = process.env.NEXT_ASSET_PREFIX;
     return [
+      ...(assetPrefix
+        ? [{ source: '/:path*', headers: [{ key: 'Link', value: `<${assetPrefix}>; rel=preconnect` }] }]
+        : []),
       {
         source: '/api/:path*',
         headers: [

--- a/src/app/(main)/(with-map)/(regions)/[region]/page.e2e.ts
+++ b/src/app/(main)/(with-map)/(regions)/[region]/page.e2e.ts
@@ -9,7 +9,7 @@ test.describe('Region page', () => {
     await expect(page.locator('h1')).toContainText('Île-de-France');
     await expect(page.locator('h1')).toContainText(/\d+ lieux/);
     await expect(page.getByText('Filtrer par département')).toBeVisible();
-    await expect(page.getByRole('link', { name: /Paris/ })).toBeVisible();
+    await expect(page.locator('main').getByRole('link', { name: /\(75\) Paris/ })).toBeVisible();
   });
 
   test('should display the list button', async ({ page }) => {
@@ -19,7 +19,10 @@ test.describe('Region page', () => {
   test('should navigate to department page', async ({ page }) => {
     await Promise.all([
       page.waitForURL(/\/ile-de-france\/seine-et-marne(\?|$)/),
-      page.getByRole('link', { name: /Seine-et-Marne/ }).click()
+      page
+        .locator('main')
+        .getByRole('link', { name: /Seine-et-Marne/ })
+        .click()
     ]);
   });
 

--- a/src/app/(main)/(with-map)/(regions)/page.e2e.ts
+++ b/src/app/(main)/(with-map)/(regions)/page.e2e.ts
@@ -8,7 +8,7 @@ test.describe('Homepage', () => {
   test('should display the homepage with regions', async ({ page }) => {
     await expect(page.locator('h1')).toContainText(/lieux.*inclusion numérique/);
     await expect(page.getByText('Filtrer par région')).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Île-de-France' })).toBeVisible();
+    await expect(page.locator('main').getByRole('link', { name: 'Île-de-France', exact: true })).toBeVisible();
   });
 
   test('should display the list button', async ({ page }) => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,6 @@ import { ConfigProvider } from '@/shared/injection';
 
 const RootLayout = ({ children }: { children: ReactNode }) => (
   <html lang='fr' suppressHydrationWarning>
-    <head>{process.env['NEXT_ASSET_PREFIX'] && <link rel='preconnect' href={process.env['NEXT_ASSET_PREFIX']} />}</head>
     <body>
       <NuqsAdapter>
         <ConfigProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { ConfigProvider } from '@/shared/injection';
 
 const RootLayout = ({ children }: { children: ReactNode }) => (
   <html lang='fr' suppressHydrationWarning>
+    <head>{process.env['NEXT_ASSET_PREFIX'] && <link rel='preconnect' href={process.env['NEXT_ASSET_PREFIX']} />}</head>
     <body>
       <NuqsAdapter>
         <ConfigProvider>

--- a/src/features/cartographie/abilities/map-view/ui/departements-on-map.tsx
+++ b/src/features/cartographie/abilities/map-view/ui/departements-on-map.tsx
@@ -22,6 +22,7 @@ export const DepartementsOnMap = ({
       href={hrefWithSearchParams(`/${regions.find(regionMatchingDepartement({ code }))?.slug}/${slug}`)(searchParams, ['page'])}
       key={code}
       prefetch={false}
+      aria-label={`${nom} : ${nombreLieux} lieux`}
       onClick={() => trackEvent({ category: MatomoCategory.NAVIGATION, action: MatomoAction.DEPARTMENT_SELECT, name: nom })}
     >
       <ClusterMarker title={`Département ${nom}`} isMuted={!selectedRegion?.departements.includes(code)} {...localisation}>

--- a/src/features/cartographie/abilities/map-view/ui/pages/regions.page.tsx
+++ b/src/features/cartographie/abilities/map-view/ui/pages/regions.page.tsx
@@ -4,10 +4,10 @@ import type { ReactNode } from 'react';
 import type { Region } from '@/libraries/collectivites';
 import { france } from '@/libraries/collectivites';
 import { inject } from '@/libraries/injection';
-import { load$, map$, setZoom } from '@/libraries/map';
+import { map$, setZoom } from '@/libraries/map';
 import { hrefWithSearchParams } from '@/libraries/nextjs';
 import { Link, useSearchParams } from '@/libraries/nextjs/shim';
-import { Subscribe, useTap } from '@/libraries/reactivity/Subscribe';
+import { useTap } from '@/libraries/reactivity/Subscribe';
 import { contentId } from '@/libraries/ui/blocks/skip-links/skip-links';
 import SkipLinksPortal from '@/libraries/ui/blocks/skip-links/skip-links-portal';
 import { LocationFranceIllustration } from '@/libraries/ui/pictograms/map/location-france.illustration';
@@ -55,23 +55,13 @@ export const RegionsPage = ({ totalLieux, regions }: { totalLieux: number; regio
       <main id={contentId} className='flex flex-col justify-between h-full gap-16'>
         <div>
           <LocationFranceIllustration className='mb-6 mt-18' />
-          <Subscribe to$={load$}>
-            {(isLoading) => (
-              <h1 className='mb-12 text-3xl text-base-title font-light'>
-                <span className='font-bold'>
-                  {isLoading ? (
-                    'Chargement des lieux...'
-                  ) : (
-                    <>
-                      {totalLieux} lieux
-                      <br />
-                      d’inclusion numérique
-                    </>
-                  )}
-                </span>
-              </h1>
-            )}
-          </Subscribe>
+          <h1 className='mb-12 text-3xl text-base-title font-light'>
+            <span className='font-bold'>
+              {totalLieux} lieux
+              <br />
+              d’inclusion numérique
+            </span>
+          </h1>
           <h2 className='font-bold uppercase text-xs text-base-title mb-3'>Filtrer par région</h2>
           <div className='flex flex-wrap gap-1.5'>
             {regions.map(({ nom, slug, code }) => (

--- a/src/features/cartographie/abilities/map-view/ui/regions-on-map.tsx
+++ b/src/features/cartographie/abilities/map-view/ui/regions-on-map.tsx
@@ -19,6 +19,7 @@ export const RegionsOnMap = ({
       href={hrefWithSearchParams(`/${slug}`)(searchParams, ['page'])}
       key={code}
       prefetch={false}
+      aria-label={`${nom} : ${nombreLieux} lieux`}
       onClick={() => trackEvent({ category: MatomoCategory.NAVIGATION, action: MatomoAction.REGION_SELECT, name: nom })}
     >
       <ClusterMarker title={`Région ${nom}`} isMuted={selectedRegion != null && selectedRegion.code !== code} {...localisation}>


### PR DESCRIPTION
The h1 with the lieux count was wrapped in a Subscribe to the map load$ stream, delaying its render until the client JS loaded and the RxJS stream resolved. Since totalLieux is available server-side, render it directly to eliminate the 1.5s element render delay reported by Lighthouse LCP breakdown.