### PR TITLE
perf: cache CSV exports with tags and increase nginx timeout

### DIFF
--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -208,6 +208,7 @@ http {
             proxy_set_header Connection '';
             proxy_http_version 1.1;
 
+            proxy_read_timeout 120s;
             limit_req zone=global burst=5 nodelay;
         }
 

--- a/src/app/(main)/(full-page)/(regions)/[region]/[departement]/lieux/exporter/route.ts
+++ b/src/app/(main)/(full-page)/(regions)/[region]/[departement]/lieux/exporter/route.ts
@@ -13,7 +13,15 @@ const ERROR_MESSAGE_MAP: { [key: number]: string } = {
 
 export const GET = routeBuilder()
   .use(withRegion(), withDepartement(), withSearchParams(filtersSchema))
-  .use(withFetch('lieux', ({ departement, searchParams }) => fetchAllLieux(departement)(searchParams)))
+  .use(
+    withFetch('lieux', ({ departement, searchParams }) => fetchAllLieux(departement)(searchParams), {
+      cache: {
+        cacheKey: ({ departement, searchParams }) => ['export', 'departement', departement.code, searchParams],
+        revalidate: false,
+        tags: ['lieux']
+      }
+    })
+  )
   .handle(
     withErrorHandler(
       ERROR_MESSAGE_MAP,

--- a/src/app/(main)/(full-page)/(regions)/[region]/lieux/exporter/route.ts
+++ b/src/app/(main)/(full-page)/(regions)/[region]/lieux/exporter/route.ts
@@ -13,7 +13,15 @@ const ERROR_MESSAGE_MAP: { [key: number]: string } = {
 
 export const GET = routeBuilder()
   .use(withRegion(), withSearchParams(filtersSchema))
-  .use(withFetch('lieux', ({ region, searchParams }) => fetchAllLieux(region)(searchParams)))
+  .use(
+    withFetch('lieux', ({ region, searchParams }) => fetchAllLieux(region)(searchParams), {
+      cache: {
+        cacheKey: ({ region, searchParams }) => ['export', 'region', region.code, searchParams],
+        revalidate: false,
+        tags: ['lieux']
+      }
+    })
+  )
   .handle(
     withErrorHandler(
       ERROR_MESSAGE_MAP,

--- a/src/app/(main)/(full-page)/(regions)/lieux/exporter/route.ts
+++ b/src/app/(main)/(full-page)/(regions)/lieux/exporter/route.ts
@@ -12,7 +12,11 @@ const ERROR_MESSAGE_MAP: { [key: number]: string } = {
 
 export const GET = routeBuilder()
   .use(withSearchParams(filtersSchema))
-  .use(withFetch('lieux', ({ searchParams }) => fetchAllLieux()(searchParams)))
+  .use(
+    withFetch('lieux', ({ searchParams }) => fetchAllLieux()(searchParams), {
+      cache: { cacheKey: ({ searchParams }) => ['export', searchParams], revalidate: false, tags: ['lieux'] }
+    })
+  )
   .handle(
     withErrorHandler(
       ERROR_MESSAGE_MAP,

--- a/src/app/api/[region]/[departement]/lieux/exporter/route.ts
+++ b/src/app/api/[region]/[departement]/lieux/exporter/route.ts
@@ -13,7 +13,15 @@ const ERROR_MESSAGE_MAP: { [key: number]: string } = {
 
 export const GET = routeBuilder()
   .use(withRegion(), withDepartement(), withSearchParams(filtersSchema))
-  .use(withFetch('lieux', ({ departement, searchParams }) => fetchAllLieux(departement)(searchParams)))
+  .use(
+    withFetch('lieux', ({ departement, searchParams }) => fetchAllLieux(departement)(searchParams), {
+      cache: {
+        cacheKey: ({ departement, searchParams }) => ['export', 'departement', departement.code, searchParams],
+        revalidate: false,
+        tags: ['lieux']
+      }
+    })
+  )
   .handle(
     withErrorHandler(
       ERROR_MESSAGE_MAP,

--- a/src/app/api/[region]/lieux/exporter/route.ts
+++ b/src/app/api/[region]/lieux/exporter/route.ts
@@ -13,7 +13,15 @@ const ERROR_MESSAGE_MAP: { [key: number]: string } = {
 
 export const GET = routeBuilder()
   .use(withRegion(), withSearchParams(filtersSchema))
-  .use(withFetch('lieux', ({ region, searchParams }) => fetchAllLieux(region)(searchParams)))
+  .use(
+    withFetch('lieux', ({ region, searchParams }) => fetchAllLieux(region)(searchParams), {
+      cache: {
+        cacheKey: ({ region, searchParams }) => ['export', 'region', region.code, searchParams],
+        revalidate: false,
+        tags: ['lieux']
+      }
+    })
+  )
   .handle(
     withErrorHandler(
       ERROR_MESSAGE_MAP,

--- a/src/app/api/lieux/exporter/route.ts
+++ b/src/app/api/lieux/exporter/route.ts
@@ -12,7 +12,11 @@ const ERROR_MESSAGE_MAP: { [key: number]: string } = {
 
 export const GET = routeBuilder()
   .use(withSearchParams(filtersSchema))
-  .use(withFetch('lieux', ({ searchParams }) => fetchAllLieux()(searchParams)))
+  .use(
+    withFetch('lieux', ({ searchParams }) => fetchAllLieux()(searchParams), {
+      cache: { cacheKey: ({ searchParams }) => ['export', searchParams], revalidate: false, tags: ['lieux'] }
+    })
+  )
   .handle(
     withErrorHandler(
       ERROR_MESSAGE_MAP,


### PR DESCRIPTION
- Add unstable_cache with tag 'lieux' on all 6 export routes so the same export is only computed once until cache reset
- Increase nginx proxy_read_timeout to 120s on /exporter routes (was 15s default, causing 504 on full export of 15,250 lieux)