### PR TITLE
fix: fix bot blocking on exports and remove unstable_cache for exports

### DIFF
--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -158,6 +158,12 @@ http {
     }
     limit_req_zone $is_bot zone=bots:1m rate=30r/m;
 
+    # Bloquer les bots sur les exports : retourne 403 si bot detecte
+    map $is_bot $deny_bot {
+        default 0;
+        "~."    1;
+    }
+
     proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=app_cache:10m max_size=256m inactive=6h use_temp_path=off;
 
     server {
@@ -196,7 +202,7 @@ http {
                 return 403;
             }
 
-            if ($is_bot) {
+            if ($deny_bot) {
                 return 403;
             }
 

--- a/src/app/(main)/(full-page)/(regions)/[region]/[departement]/lieux/exporter/route.ts
+++ b/src/app/(main)/(full-page)/(regions)/[region]/[departement]/lieux/exporter/route.ts
@@ -13,15 +13,7 @@ const ERROR_MESSAGE_MAP: { [key: number]: string } = {
 
 export const GET = routeBuilder()
   .use(withRegion(), withDepartement(), withSearchParams(filtersSchema))
-  .use(
-    withFetch('lieux', ({ departement, searchParams }) => fetchAllLieux(departement)(searchParams), {
-      cache: {
-        cacheKey: ({ departement, searchParams }) => ['export', 'departement', departement.code, searchParams],
-        revalidate: false,
-        tags: ['lieux']
-      }
-    })
-  )
+  .use(withFetch('lieux', ({ departement, searchParams }) => fetchAllLieux(departement)(searchParams)))
   .handle(
     withErrorHandler(
       ERROR_MESSAGE_MAP,

--- a/src/app/(main)/(full-page)/(regions)/[region]/lieux/exporter/route.ts
+++ b/src/app/(main)/(full-page)/(regions)/[region]/lieux/exporter/route.ts
@@ -13,15 +13,7 @@ const ERROR_MESSAGE_MAP: { [key: number]: string } = {
 
 export const GET = routeBuilder()
   .use(withRegion(), withSearchParams(filtersSchema))
-  .use(
-    withFetch('lieux', ({ region, searchParams }) => fetchAllLieux(region)(searchParams), {
-      cache: {
-        cacheKey: ({ region, searchParams }) => ['export', 'region', region.code, searchParams],
-        revalidate: false,
-        tags: ['lieux']
-      }
-    })
-  )
+  .use(withFetch('lieux', ({ region, searchParams }) => fetchAllLieux(region)(searchParams)))
   .handle(
     withErrorHandler(
       ERROR_MESSAGE_MAP,

--- a/src/app/(main)/(full-page)/(regions)/lieux/exporter/route.ts
+++ b/src/app/(main)/(full-page)/(regions)/lieux/exporter/route.ts
@@ -12,11 +12,7 @@ const ERROR_MESSAGE_MAP: { [key: number]: string } = {
 
 export const GET = routeBuilder()
   .use(withSearchParams(filtersSchema))
-  .use(
-    withFetch('lieux', ({ searchParams }) => fetchAllLieux()(searchParams), {
-      cache: { cacheKey: ({ searchParams }) => ['export', searchParams], revalidate: false, tags: ['lieux'] }
-    })
-  )
+  .use(withFetch('lieux', ({ searchParams }) => fetchAllLieux()(searchParams)))
   .handle(
     withErrorHandler(
       ERROR_MESSAGE_MAP,

--- a/src/app/api/[region]/[departement]/lieux/exporter/route.ts
+++ b/src/app/api/[region]/[departement]/lieux/exporter/route.ts
@@ -13,15 +13,7 @@ const ERROR_MESSAGE_MAP: { [key: number]: string } = {
 
 export const GET = routeBuilder()
   .use(withRegion(), withDepartement(), withSearchParams(filtersSchema))
-  .use(
-    withFetch('lieux', ({ departement, searchParams }) => fetchAllLieux(departement)(searchParams), {
-      cache: {
-        cacheKey: ({ departement, searchParams }) => ['export', 'departement', departement.code, searchParams],
-        revalidate: false,
-        tags: ['lieux']
-      }
-    })
-  )
+  .use(withFetch('lieux', ({ departement, searchParams }) => fetchAllLieux(departement)(searchParams)))
   .handle(
     withErrorHandler(
       ERROR_MESSAGE_MAP,

--- a/src/app/api/[region]/lieux/exporter/route.ts
+++ b/src/app/api/[region]/lieux/exporter/route.ts
@@ -13,15 +13,7 @@ const ERROR_MESSAGE_MAP: { [key: number]: string } = {
 
 export const GET = routeBuilder()
   .use(withRegion(), withSearchParams(filtersSchema))
-  .use(
-    withFetch('lieux', ({ region, searchParams }) => fetchAllLieux(region)(searchParams), {
-      cache: {
-        cacheKey: ({ region, searchParams }) => ['export', 'region', region.code, searchParams],
-        revalidate: false,
-        tags: ['lieux']
-      }
-    })
-  )
+  .use(withFetch('lieux', ({ region, searchParams }) => fetchAllLieux(region)(searchParams)))
   .handle(
     withErrorHandler(
       ERROR_MESSAGE_MAP,

--- a/src/app/api/lieux/exporter/route.ts
+++ b/src/app/api/lieux/exporter/route.ts
@@ -12,11 +12,7 @@ const ERROR_MESSAGE_MAP: { [key: number]: string } = {
 
 export const GET = routeBuilder()
   .use(withSearchParams(filtersSchema))
-  .use(
-    withFetch('lieux', ({ searchParams }) => fetchAllLieux()(searchParams), {
-      cache: { cacheKey: ({ searchParams }) => ['export', searchParams], revalidate: false, tags: ['lieux'] }
-    })
-  )
+  .use(withFetch('lieux', ({ searchParams }) => fetchAllLieux()(searchParams)))
   .handle(
     withErrorHandler(
       ERROR_MESSAGE_MAP,


### PR DESCRIPTION
- nginx: use $deny_bot map instead of $is_bot in if-block to fix unreliable bot detection in /exporter location (nginx if-is-evil)
- Remove unstable_cache from all 6 export routes — Next.js data cache has a 2MB limit which large regional exports exceed (2.3MB for Hauts-de-France), causing errors. Exports are protected by bot blocking + streaming, and served from the in-memory lieux cache.