### PR TITLE
fix: add AI bots to nginx rate limiting and export blocking

### DIFF
--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -155,6 +155,12 @@ http {
         "~*mj12bot"     "mj12bot";
         "~*facebookexternalhit" "facebookexternalhit";
         "~*meta-externalagent"  "meta-externalagent";
+        "~*ChatGPT-User"  "chatgpt";
+        "~*GPTBot"        "gptbot";
+        "~*CCBot"         "ccbot";
+        "~*ClaudeBot"     "claudebot";
+        "~*anthropic-ai"  "anthropic";
+        "~*Bytespider"    "bytespider";
     }
     limit_req_zone $is_bot zone=bots:1m rate=30r/m;
 


### PR DESCRIPTION
ChatGPT-User was crawling /lieux/exporter (14.7s, blocking the event loop) despite being blocked in robots.txt — it wasn't in the nginx $is_bot map.

Add all AI bots from robots.txt to nginx: ChatGPT-User, GPTBot, CCBot, ClaudeBot, anthropic-ai, Bytespider.