### PR TITLE
fix: use browser history for back navigation from lieu detail page

### DIFF
--- a/src/app/(main)/(full-page)/(regions)/[region]/[departement]/lieux/[id]/page.e2e.ts
+++ b/src/app/(main)/(full-page)/(regions)/[region]/[departement]/lieux/[id]/page.e2e.ts
@@ -25,7 +25,7 @@ test.describe('Lieu detail page', () => {
 
   test('should navigate back to list', async ({ page }) => {
     await Promise.all([
-      page.waitForURL(/\/ile-de-france\/seine-et-marne(\?|$)/),
+      page.waitForURL(/\/ile-de-france\/seine-et-marne\/lieux(\?|$)/),
       page.getByRole('link', { name: /Retour à la liste/ }).click()
     ]);
   });

--- a/src/features/lieux-inclusion-numerique/abilities/detail-view/ui/fiche-lieu.page.tsx
+++ b/src/features/lieux-inclusion-numerique/abilities/detail-view/ui/fiche-lieu.page.tsx
@@ -7,6 +7,7 @@ import { Breadcrumbs } from '@/libraries/ui/blocks/breadcrumbs';
 import { ClipboardButton } from '@/libraries/ui/blocks/clipboard-button';
 import { contentId } from '@/libraries/ui/blocks/skip-links/skip-links';
 import SkipLinksPortal from '@/libraries/ui/blocks/skip-links/skip-links-portal';
+import { BackButtonLink } from '@/libraries/ui/primitives/back-button-link';
 import { ButtonLink } from '@/libraries/ui/primitives/button-link';
 import { Accompagnement } from './sections/accompagnement';
 import { ContactCard } from './sections/contact-card';
@@ -43,10 +44,10 @@ export const FicheLieuPage = ({ breadcrumbsItems = [], listHref, lieu, lieuUrl }
     <Breadcrumbs items={breadcrumbsItems} className='px-8 py-4 border-b border-base-200' />
     <main id={contentId} className='container mx-auto px-4 lg:flex gap-16'>
       <article className='flex-1/2 lg:flex-2/3 2xl:flex-3/4 mb-12'>
-        <ButtonLink kind='btn-link' href={hrefWithSearchParams(listHref)()} className='no-underline my-4 px-2'>
+        <BackButtonLink kind='btn-link' href={hrefWithSearchParams(listHref)()} className='no-underline my-4 px-2'>
           <RiArrowGoBackLine size={16} aria-hidden={true} />
           Retour à la liste
-        </ButtonLink>
+        </BackButtonLink>
         <InformationsGenerales {...lieu} />
         <hr className='border-base-200 mt-4 mb-6' />
         <section>

--- a/src/libraries/nextjs/shim/navigation.wc.tsx
+++ b/src/libraries/nextjs/shim/navigation.wc.tsx
@@ -20,6 +20,7 @@ export const useRouter = () => {
   return useMemo(
     () => ({
       push: (url: string) => navigate({ to: url }),
+      back: () => window.history.back(),
       refresh: () => router.invalidate()
     }),
     [navigate, router]

--- a/src/libraries/ui/primitives/back-button-link.tsx
+++ b/src/libraries/ui/primitives/back-button-link.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import type { MouseEvent, ReactNode } from 'react';
+import { useRouter } from '@/libraries/nextjs/shim';
+import { ButtonLink, type ButtonLinkProps } from './button-link';
+
+export const BackButtonLink = ({ onClick, ...props }: ButtonLinkProps): ReactNode => {
+  const router = useRouter();
+
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    const navEntry = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
+    const hasNavigatedInternally = navEntry != null && navEntry.name !== window.location.href;
+
+    if (hasNavigatedInternally) {
+      e.preventDefault();
+      router.back();
+    }
+
+    onClick?.(e);
+  };
+
+  return <ButtonLink {...props} onClick={handleClick} />;
+};


### PR DESCRIPTION
When navigating from the list or map to a lieu detail page, the back button now uses router.back() to return to the previous page, preserving filters and scroll position. Falls back to the list href for direct access (external link, refresh, new tab).