### PR TITLE
feat: add embed map button in navbar with Matomo tracking

### DIFF
--- a/src/features/brand/abilities/layout/navbar.tsx
+++ b/src/features/brand/abilities/layout/navbar.tsx
@@ -2,7 +2,8 @@
 
 import type { ReactNode } from 'react';
 import { Suspense } from 'react';
-import { RiMenuLine, RiQuestionFill } from 'react-icons/ri';
+import { RiCodeBlock, RiMenuLine, RiQuestionFill } from 'react-icons/ri';
+import { MatomoAction, MatomoCategory, trackEvent } from '@/libraries/analytics';
 import { inject } from '@/libraries/injection';
 import { hrefWithSearchParams } from '@/libraries/nextjs';
 import { useSearchParams } from '@/libraries/nextjs/shim';
@@ -88,6 +89,16 @@ export const Navbar = ({ searchSlot, filtersSlot }: NavbarProps) => {
                   {helpLabel ?? 'Aide'}
                 </ButtonLink>
               )}
+              <ButtonLink
+                href='https://tally.so/r/VLV5K6'
+                kind='btn-link'
+                className='no-underline'
+                target='_blank'
+                onClick={() => trackEvent({ category: MatomoCategory.EMBED, action: MatomoAction.EMBED_MAP_CLICK })}
+              >
+                <RiCodeBlock size={16} />
+                Intégrer la carte sur votre site
+              </ButtonLink>
               <Button kind='btn-link' className='px-2 lg:hidden' {...toggle}>
                 <RiMenuLine size={24} aria-hidden={true} />
               </Button>

--- a/src/libraries/analytics/tracking/events.ts
+++ b/src/libraries/analytics/tracking/events.ts
@@ -4,7 +4,8 @@ export const MatomoCategory = {
   EXPORT: 'Export',
   MAP: 'Map',
   FILTER: 'Filter',
-  LOCATION: 'Location'
+  LOCATION: 'Location',
+  EMBED: 'Embed'
 } as const;
 
 export const MatomoAction = {
@@ -18,7 +19,8 @@ export const MatomoAction = {
   ZOOM_CHANGE: 'zoom_change',
   LAYER_TOGGLE: 'layer_toggle',
   FULLSCREEN_TOGGLE: 'fullscreen_toggle',
-  FILTER_APPLY: 'filter_apply'
+  FILTER_APPLY: 'filter_apply',
+  EMBED_MAP_CLICK: 'embed_map_click'
 } as const;
 
 export type MatomoCategoryType = (typeof MatomoCategory)[keyof typeof MatomoCategory];


### PR DESCRIPTION
Add a button in the header to redirect users to the Tally form for embedding the map on their website. Track clicks with Matomo event embed_map_click.