### PR TITLE
fix: gracefully handle invalid territoire_type query parameter

### DIFF
--- a/src/libraries/inclusion-numerique-api/filters/filters.schema.ts
+++ b/src/libraries/inclusion-numerique-api/filters/filters.schema.ts
@@ -64,7 +64,7 @@ export const filtersSchema = z.object({
   prise_rdv: commaSeparatedEnumArray(priseRDVEnum),
   dispositif_programmes_nationaux: commaSeparatedEnumArray(dispositifProgrammesNationauxEnum),
   autres_formations_labels: commaSeparatedEnumArray(autresFormationsLabelsEnum),
-  territoire_type: territoireTypeEnum.optional(),
+  territoire_type: territoireTypeEnum.optional().catch(undefined),
   territoires: commaSeparatedStringArray
 });
 


### PR DESCRIPTION
Add .catch(undefined) to territoire_type schema validation so that malformed URLs (e.g. territoire_type=communes=69028) are silently ignored instead of causing a 500 error.