### PR TITLE
feat: provision Scaleway TEM domain and inject SMTP config into container

### DIFF
--- a/infrastructure/src/index.ts
+++ b/infrastructure/src/index.ts
@@ -1,3 +1,4 @@
 export * from './resources/cockpit';
 export * from './resources/container';
+export * from './resources/email';
 export * from './resources/static';

--- a/infrastructure/src/resources/container.ts
+++ b/infrastructure/src/resources/container.ts
@@ -1,6 +1,8 @@
 import { containers } from '@pulumiverse/scaleway';
 import { config } from '../config';
+import { env } from '../env';
 import { name } from '../utils/name';
+import { EMAIL_SMTP_HOST, EMAIL_SMTP_PORT } from './email';
 import { APP_IMAGE_NAME } from './image';
 import { scalewayProvider } from './scaleway.provider';
 
@@ -30,7 +32,13 @@ const container = new containers.Container(
     port: 80,
     protocol: 'http1',
     environmentVariables: {
-      HOSTNAME: '0.0.0.0'
+      HOSTNAME: '0.0.0.0',
+      SMTP_HOST: EMAIL_SMTP_HOST,
+      SMTP_PORT: EMAIL_SMTP_PORT.apply((port) => String(port)),
+      SMTP_USER: env.SCW_DEFAULT_PROJECT_ID,
+      SMTP_PASS: env.SCW_SECRET_KEY,
+      CONTACT_EMAIL_TO: 'cartographie.sonum@anct.gouv.fr',
+      CONTACT_EMAIL_FROM: 'ne-pas-repondre@cartographie.anct.gouv.fr'
     },
     healthChecks: [
       {

--- a/infrastructure/src/resources/email.ts
+++ b/infrastructure/src/resources/email.ts
@@ -1,0 +1,23 @@
+import { tem } from '@pulumiverse/scaleway';
+import { config } from '../config';
+import { name } from '../utils/name';
+import { scalewayProvider } from './scaleway.provider';
+
+const domain = new tem.Domain(
+  name('email-domain'),
+  {
+    name: 'cartographie.anct.gouv.fr',
+    acceptTos: true,
+    region: 'fr-par'
+  },
+  { provider: scalewayProvider }
+);
+
+export const EMAIL_SMTP_HOST = domain.smtpHost;
+export const EMAIL_SMTP_PORT = domain.smtpPort;
+export const EMAIL_DKIM_CONFIG = domain.dkimConfig;
+export const EMAIL_SPF_CONFIG = domain.spfValue;
+export const EMAIL_DMARC_NAME = domain.dmarcName;
+export const EMAIL_DMARC_CONFIG = domain.dmarcConfig;
+export const EMAIL_MX_CONFIG = domain.mxConfig;
+export const EMAIL_STATUS = domain.status;


### PR DESCRIPTION
Add Transactional Email domain for cartographie.anct.gouv.fr via Pulumi. Inject SMTP environment variables into the Serverless Container using TEM outputs and Scaleway credentials. Export DNS records (DKIM, SPF, DMARC) for admin team to configure.