### PR TITLE
feat: add open now and open weekends availability filters with cached OpeningHours parsing

### DIFF
--- a/src/features/collectivites-territoriales/abilities/stats-query/stats.ts
+++ b/src/features/collectivites-territoriales/abilities/stats-query/stats.ts
@@ -6,7 +6,7 @@ import {
   type Region
 } from '@/libraries/collectivites';
 import type { FiltersSchema } from '@/libraries/inclusion-numerique-api';
-import { filterLieux, getAllLieux, getOpeningHoursCache } from '@/libraries/lieux-cache';
+import { filterLieux, getAllLieux, getOpeningHoursCache, needsOpeningHoursCache } from '@/libraries/lieux-cache';
 import { aggregateByDepartement } from './aggregate-by-departement';
 
 export type RegionWithCount = Region & { nombreLieux: number };
@@ -18,7 +18,10 @@ const toRegionTotalCount = (departementsAvecTotaux: DepartementWithCount[]) => (
 export type AllStats = { regions: RegionWithCount[]; departements: DepartementWithCount[] };
 
 export const fetchAllStats = async (filters: FiltersSchema): Promise<AllStats> => {
-  const [allLieux, ohCache] = await Promise.all([getAllLieux(), getOpeningHoursCache()]);
+  const [allLieux, ohCache] = await Promise.all([
+    getAllLieux(),
+    needsOpeningHoursCache(filters) ? getOpeningHoursCache() : undefined
+  ]);
   const filtered = filterLieux(allLieux, filters, undefined, ohCache);
   const codeInsees = filtered.map((lieu) => lieu.adresse.code_insee).filter(Boolean);
   const countsByDept = aggregateByDepartement(codeInsees);

--- a/src/features/collectivites-territoriales/abilities/stats-query/stats.ts
+++ b/src/features/collectivites-territoriales/abilities/stats-query/stats.ts
@@ -6,7 +6,7 @@ import {
   type Region
 } from '@/libraries/collectivites';
 import type { FiltersSchema } from '@/libraries/inclusion-numerique-api';
-import { filterLieux, getAllLieux } from '@/libraries/lieux-cache';
+import { filterLieux, getAllLieux, getOpeningHoursCache } from '@/libraries/lieux-cache';
 import { aggregateByDepartement } from './aggregate-by-departement';
 
 export type RegionWithCount = Region & { nombreLieux: number };
@@ -18,8 +18,8 @@ const toRegionTotalCount = (departementsAvecTotaux: DepartementWithCount[]) => (
 export type AllStats = { regions: RegionWithCount[]; departements: DepartementWithCount[] };
 
 export const fetchAllStats = async (filters: FiltersSchema): Promise<AllStats> => {
-  const allLieux = await getAllLieux();
-  const filtered = filterLieux(allLieux, filters);
+  const [allLieux, ohCache] = await Promise.all([getAllLieux(), getOpeningHoursCache()]);
+  const filtered = filterLieux(allLieux, filters, undefined, ohCache);
   const codeInsees = filtered.map((lieu) => lieu.adresse.code_insee).filter(Boolean);
   const countsByDept = aggregateByDepartement(codeInsees);
 

--- a/src/features/lieux-inclusion-numerique/abilities/count/count-lieux.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/count/count-lieux.ts
@@ -1,9 +1,9 @@
 import type { Collectivite, FiltersSchema } from '@/libraries/inclusion-numerique-api';
-import { filterLieux, getAllLieux } from '@/libraries/lieux-cache';
+import { filterLieux, getAllLieux, getOpeningHoursCache } from '@/libraries/lieux-cache';
 
 export const countLieux =
   (collectivite?: Collectivite) =>
   async (filters: FiltersSchema): Promise<number> => {
-    const allLieux = await getAllLieux();
-    return filterLieux(allLieux, filters, collectivite).length;
+    const [allLieux, ohCache] = await Promise.all([getAllLieux(), getOpeningHoursCache()]);
+    return filterLieux(allLieux, filters, collectivite, ohCache).length;
   };

--- a/src/features/lieux-inclusion-numerique/abilities/count/count-lieux.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/count/count-lieux.ts
@@ -1,9 +1,12 @@
 import type { Collectivite, FiltersSchema } from '@/libraries/inclusion-numerique-api';
-import { filterLieux, getAllLieux, getOpeningHoursCache } from '@/libraries/lieux-cache';
+import { filterLieux, getAllLieux, getOpeningHoursCache, needsOpeningHoursCache } from '@/libraries/lieux-cache';
 
 export const countLieux =
   (collectivite?: Collectivite) =>
   async (filters: FiltersSchema): Promise<number> => {
-    const [allLieux, ohCache] = await Promise.all([getAllLieux(), getOpeningHoursCache()]);
+    const [allLieux, ohCache] = await Promise.all([
+      getAllLieux(),
+      needsOpeningHoursCache(filters) ? getOpeningHoursCache() : undefined
+    ]);
     return filterLieux(allLieux, filters, collectivite, ohCache).length;
   };

--- a/src/features/lieux-inclusion-numerique/abilities/export/query/fetch-all-lieux.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/export/query/fetch-all-lieux.ts
@@ -1,9 +1,9 @@
 import type { Collectivite, FiltersSchema, LieuxRouteResponse } from '@/libraries/inclusion-numerique-api';
-import { filterLieux, getAllLieux } from '@/libraries/lieux-cache';
+import { filterLieux, getAllLieux, getOpeningHoursCache } from '@/libraries/lieux-cache';
 
 export const fetchAllLieux =
   (collectivite?: Collectivite) =>
   async (filters: FiltersSchema): Promise<LieuxRouteResponse> => {
-    const allLieux = await getAllLieux();
-    return filterLieux(allLieux, filters, collectivite);
+    const [allLieux, ohCache] = await Promise.all([getAllLieux(), getOpeningHoursCache()]);
+    return filterLieux(allLieux, filters, collectivite, ohCache);
   };

--- a/src/features/lieux-inclusion-numerique/abilities/export/query/fetch-all-lieux.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/export/query/fetch-all-lieux.ts
@@ -1,9 +1,12 @@
 import type { Collectivite, FiltersSchema, LieuxRouteResponse } from '@/libraries/inclusion-numerique-api';
-import { filterLieux, getAllLieux, getOpeningHoursCache } from '@/libraries/lieux-cache';
+import { filterLieux, getAllLieux, getOpeningHoursCache, needsOpeningHoursCache } from '@/libraries/lieux-cache';
 
 export const fetchAllLieux =
   (collectivite?: Collectivite) =>
   async (filters: FiltersSchema): Promise<LieuxRouteResponse> => {
-    const [allLieux, ohCache] = await Promise.all([getAllLieux(), getOpeningHoursCache()]);
+    const [allLieux, ohCache] = await Promise.all([
+      getAllLieux(),
+      needsOpeningHoursCache(filters) ? getOpeningHoursCache() : undefined
+    ]);
     return filterLieux(allLieux, filters, collectivite, ohCache);
   };

--- a/src/features/lieux-inclusion-numerique/abilities/filters/ui/disponibilite-filters.tsx
+++ b/src/features/lieux-inclusion-numerique/abilities/filters/ui/disponibilite-filters.tsx
@@ -13,29 +13,54 @@ const fraisAChargeOptions = [{ label: 'Gratuit', value: 'Gratuit', id: 'gratuit'
 
 const priseRdvOptions = [{ label: 'Prise de RDV en ligne', value: 'Prise de RDV en ligne', id: 'prise-de-rdv-en-ligne' }];
 
+const ouvertActuellementOptions = [{ label: 'Ouvert actuellement', value: 'true', id: 'ouvert-actuellement' }];
+
+const ouvertLeWeekEndOptions = [{ label: 'Ouvert le week-end', value: 'true', id: 'ouvert-le-week-end' }];
+
+const roundToQuarterHour = (date: Date): string => {
+  const rounded = new Date(date);
+  rounded.setMinutes(Math.floor(rounded.getMinutes() / 15) * 15, 0, 0);
+  return rounded.toISOString();
+};
+
 export const DisponibiliteFilters = () => {
   const router = useRouter();
   const [, startTransition] = useTransitionWithCallback(endLoad);
 
   const [fraisACharge, setFraisACharge] = useQueryState('frais_a_charge', { defaultValue: '' });
   const [priseRdv, setPriseRdv] = useQueryState('prise_rdv', { defaultValue: '' });
+  const [ouvertActuellement, setOuvertActuellement] = useQueryState('ouvert_actuellement', { defaultValue: '' });
+  const [ouvertLeWeekEnd, setOuvertLeWeekEnd] = useQueryState('ouvert_le_week_end', { defaultValue: '' });
 
   const defaultValues = {
     fraisACharge: fraisACharge.split(',').filter(noEmptyString),
-    priseRdv: priseRdv.split(',').filter(noEmptyString)
+    priseRdv: priseRdv.split(',').filter(noEmptyString),
+    ouvertActuellement: ouvertActuellement ? ['true'] : [],
+    ouvertLeWeekEnd: ouvertLeWeekEnd ? ['true'] : []
   };
 
-  const selectedFiltersCount = defaultValues.fraisACharge.length + defaultValues.priseRdv.length;
+  const selectedFiltersCount =
+    defaultValues.fraisACharge.length +
+    defaultValues.priseRdv.length +
+    defaultValues.ouvertActuellement.length +
+    defaultValues.ouvertLeWeekEnd.length;
 
   const form = useAppForm({
     defaultValues,
     onSubmit: async ({ value }) => {
-      if (arraysEqual(defaultValues.fraisACharge)(value.fraisACharge) && arraysEqual(defaultValues.priseRdv)(value.priseRdv))
+      if (
+        arraysEqual(defaultValues.fraisACharge)(value.fraisACharge) &&
+        arraysEqual(defaultValues.priseRdv)(value.priseRdv) &&
+        arraysEqual(defaultValues.ouvertActuellement)(value.ouvertActuellement) &&
+        arraysEqual(defaultValues.ouvertLeWeekEnd)(value.ouvertLeWeekEnd)
+      )
         return;
 
       startTransition(async () => {
         await setFraisACharge(value.fraisACharge.filter(noEmptyString).join(','));
         await setPriseRdv(value.priseRdv.filter(noEmptyString).join(','));
+        await setOuvertActuellement(value.ouvertActuellement.includes('true') ? roundToQuarterHour(new Date()) : '');
+        await setOuvertLeWeekEnd(value.ouvertLeWeekEnd.includes('true') ? 'true' : '');
         startLoad();
         router.refresh();
       });
@@ -59,6 +84,12 @@ export const DisponibiliteFilters = () => {
         onClose={form.handleSubmit}
       >
         <div className='p-8 flex flex-col gap-2'>
+          <form.AppField name='ouvertActuellement'>
+            {(field) => <field.CheckboxGroup options={ouvertActuellementOptions} isPending={false} />}
+          </form.AppField>
+          <form.AppField name='ouvertLeWeekEnd'>
+            {(field) => <field.CheckboxGroup options={ouvertLeWeekEndOptions} isPending={false} />}
+          </form.AppField>
           <form.AppField name='fraisACharge'>
             {(field) => <field.CheckboxGroup options={fraisAChargeOptions} isPending={false} />}
           </form.AppField>

--- a/src/features/lieux-inclusion-numerique/abilities/list-view/query/fetch-lieux.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/list-view/query/fetch-lieux.ts
@@ -4,7 +4,7 @@ import {
   LIEU_LIST_FIELDS,
   type LieuxRouteResponse
 } from '@/libraries/inclusion-numerique-api';
-import { filterLieux, getAllLieux, getOpeningHoursCache } from '@/libraries/lieux-cache';
+import { filterLieux, getAllLieux, getOpeningHoursCache, needsOpeningHoursCache } from '@/libraries/lieux-cache';
 
 type PaginationParams = {
   page: number;
@@ -22,7 +22,10 @@ const pick = (lieu: LieuxRouteResponse[number]): LieuxRouteResponse[number] =>
 export const fetchLieux =
   (collectivite?: Collectivite) =>
   async (filters: FiltersSchema, { page, limit }: PaginationParams): Promise<LieuxWithTotal> => {
-    const [allLieux, ohCache] = await Promise.all([getAllLieux(), getOpeningHoursCache()]);
+    const [allLieux, ohCache] = await Promise.all([
+      getAllLieux(),
+      needsOpeningHoursCache(filters) ? getOpeningHoursCache() : undefined
+    ]);
     const filtered = filterLieux(allLieux, filters, collectivite, ohCache);
     return { lieux: filtered.slice((page - 1) * limit, page * limit).map(pick), total: filtered.length };
   };

--- a/src/features/lieux-inclusion-numerique/abilities/list-view/query/fetch-lieux.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/list-view/query/fetch-lieux.ts
@@ -4,7 +4,7 @@ import {
   LIEU_LIST_FIELDS,
   type LieuxRouteResponse
 } from '@/libraries/inclusion-numerique-api';
-import { filterLieux, getAllLieux } from '@/libraries/lieux-cache';
+import { filterLieux, getAllLieux, getOpeningHoursCache } from '@/libraries/lieux-cache';
 
 type PaginationParams = {
   page: number;
@@ -22,7 +22,7 @@ const pick = (lieu: LieuxRouteResponse[number]): LieuxRouteResponse[number] =>
 export const fetchLieux =
   (collectivite?: Collectivite) =>
   async (filters: FiltersSchema, { page, limit }: PaginationParams): Promise<LieuxWithTotal> => {
-    const allLieux = await getAllLieux();
-    const filtered = filterLieux(allLieux, filters, collectivite);
+    const [allLieux, ohCache] = await Promise.all([getAllLieux(), getOpeningHoursCache()]);
+    const filtered = filterLieux(allLieux, filters, collectivite, ohCache);
     return { lieux: filtered.slice((page - 1) * limit, page * limit).map(pick), total: filtered.length };
   };

--- a/src/features/lieux-inclusion-numerique/abilities/map-view/query/fetch-lieux-for-chunk.server.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/map-view/query/fetch-lieux-for-chunk.server.ts
@@ -1,21 +1,26 @@
 import type { BBox } from 'geojson';
 import type { FiltersSchema } from '@/libraries/inclusion-numerique-api';
-import { filterLieux, getAllLieux } from '@/libraries/lieux-cache';
+import { filterLieux, getAllLieux, getOpeningHoursCache } from '@/libraries/lieux-cache';
 import { MAP_CHUNK_OPTIONS, mapChunk, type Position2D } from '@/libraries/map';
 
 export const fetchLieuxForChunkServer = async (position: Position2D, filters: FiltersSchema) => {
   const [minLon, minLat, maxLon, maxLat]: BBox = mapChunk(position, MAP_CHUNK_OPTIONS);
-  const allLieux = await getAllLieux();
+  const [allLieux, ohCache] = await Promise.all([getAllLieux(), getOpeningHoursCache()]);
 
-  return filterLieux(allLieux, filters)
-    .filter(
-      (lieu) =>
-        lieu.latitude != null &&
-        lieu.longitude != null &&
-        lieu.latitude > minLat &&
-        lieu.latitude <= maxLat &&
-        lieu.longitude > minLon &&
-        lieu.longitude <= maxLon
-    )
-    .map(({ id, nom, latitude, longitude }) => ({ id, nom, latitude, longitude }));
+  const chunkLieux = allLieux.filter(
+    (lieu) =>
+      lieu.latitude != null &&
+      lieu.longitude != null &&
+      lieu.latitude > minLat &&
+      lieu.latitude <= maxLat &&
+      lieu.longitude > minLon &&
+      lieu.longitude <= maxLon
+  );
+
+  return filterLieux(chunkLieux, filters, undefined, ohCache).map(({ id, nom, latitude, longitude }) => ({
+    id,
+    nom,
+    latitude,
+    longitude
+  }));
 };

--- a/src/features/lieux-inclusion-numerique/abilities/map-view/query/fetch-lieux-for-chunk.server.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/map-view/query/fetch-lieux-for-chunk.server.ts
@@ -1,11 +1,14 @@
 import type { BBox } from 'geojson';
 import type { FiltersSchema } from '@/libraries/inclusion-numerique-api';
-import { filterLieux, getAllLieux, getOpeningHoursCache } from '@/libraries/lieux-cache';
+import { filterLieux, getAllLieux, getOpeningHoursCache, needsOpeningHoursCache } from '@/libraries/lieux-cache';
 import { MAP_CHUNK_OPTIONS, mapChunk, type Position2D } from '@/libraries/map';
 
 export const fetchLieuxForChunkServer = async (position: Position2D, filters: FiltersSchema) => {
   const [minLon, minLat, maxLon, maxLat]: BBox = mapChunk(position, MAP_CHUNK_OPTIONS);
-  const [allLieux, ohCache] = await Promise.all([getAllLieux(), getOpeningHoursCache()]);
+  const [allLieux, ohCache] = await Promise.all([
+    getAllLieux(),
+    needsOpeningHoursCache(filters) ? getOpeningHoursCache() : undefined
+  ]);
 
   const chunkLieux = allLieux.filter(
     (lieu) =>

--- a/src/libraries/inclusion-numerique-api/filters/filters.schema.ts
+++ b/src/libraries/inclusion-numerique-api/filters/filters.schema.ts
@@ -56,6 +56,14 @@ const commaSeparatedStringArray = z
   )
   .catch([]);
 
+const optionalIsoDate = z.string().datetime({ offset: true }).optional().catch(undefined);
+
+const optionalBoolean = z
+  .enum(['true', 'false'])
+  .transform((val) => val === 'true')
+  .optional()
+  .catch(undefined);
+
 export const filtersSchema = z.object({
   services: commaSeparatedEnumArray(servicesEnum),
   publics_specifiquement_adresses: commaSeparatedEnumArray(publicsSpecifiquementAdressesEnum),
@@ -65,7 +73,9 @@ export const filtersSchema = z.object({
   dispositif_programmes_nationaux: commaSeparatedEnumArray(dispositifProgrammesNationauxEnum),
   autres_formations_labels: commaSeparatedEnumArray(autresFormationsLabelsEnum),
   territoire_type: territoireTypeEnum.optional().catch(undefined),
-  territoires: commaSeparatedStringArray
+  territoires: commaSeparatedStringArray,
+  ouvert_actuellement: optionalIsoDate,
+  ouvert_le_week_end: optionalBoolean
 });
 
 export type FiltersSchema = z.infer<typeof filtersSchema>;

--- a/src/libraries/lieux-cache/filter-lieux.spec.ts
+++ b/src/libraries/lieux-cache/filter-lieux.spec.ts
@@ -271,9 +271,9 @@ describe('filterLieux', () => {
         lieu({ id: '3' })
       ];
       const ohCache = buildOpeningHoursCache(lieux);
-      const wednesdayAt10 = '2026-05-06T10:00:00.000+02:00';
+      const wednesdayAt12UTC = '2026-05-06T12:00:00.000Z';
 
-      const result = filterLieux(lieux, { ...emptyFilters, ouvert_actuellement: wednesdayAt10 }, undefined, ohCache);
+      const result = filterLieux(lieux, { ...emptyFilters, ouvert_actuellement: wednesdayAt12UTC }, undefined, ohCache);
 
       expect(result).toHaveLength(1);
       expect(result[0]?.id).toBe('1');
@@ -285,7 +285,7 @@ describe('filterLieux', () => {
 
       const result = filterLieux(
         lieux,
-        { ...emptyFilters, ouvert_actuellement: '2026-05-06T10:00:00.000+02:00' },
+        { ...emptyFilters, ouvert_actuellement: '2026-05-06T12:00:00.000Z' },
         undefined,
         ohCache
       );
@@ -299,7 +299,7 @@ describe('filterLieux', () => {
 
       const result = filterLieux(
         lieux,
-        { ...emptyFilters, ouvert_actuellement: '2026-05-06T10:00:00.000+02:00' },
+        { ...emptyFilters, ouvert_actuellement: '2026-05-06T12:00:00.000Z' },
         undefined,
         ohCache
       );

--- a/src/libraries/lieux-cache/filter-lieux.spec.ts
+++ b/src/libraries/lieux-cache/filter-lieux.spec.ts
@@ -1,6 +1,8 @@
+import OpeningHours from 'opening_hours';
 import { describe, expect, it } from 'vitest';
 import type { FiltersSchema, LieuxRouteResponse } from '@/libraries/inclusion-numerique-api';
 import { filterLieux } from './filter-lieux';
+import type { OpeningHoursCache } from './lieux-cache';
 
 const emptyFilters: FiltersSchema = {
   services: [],
@@ -24,6 +26,41 @@ const lieu = (overrides: Partial<LieuxRouteResponse[number]> = {}): LieuxRouteRe
     services: [],
     ...overrides
   }) as LieuxRouteResponse[number];
+
+const buildOpeningHoursCache = (lieux: LieuxRouteResponse): OpeningHoursCache => {
+  const parsed = new Map<string, OpeningHours>();
+  const openOnWeekend = new Set<string>();
+
+  const now = new Date();
+  const saturdayStart = new Date(now);
+  saturdayStart.setDate(saturdayStart.getDate() + ((6 - now.getDay() + 7) % 7 || 7));
+  saturdayStart.setHours(0, 0, 0, 0);
+  const saturdayEnd = new Date(saturdayStart);
+  saturdayEnd.setHours(23, 59, 59, 999);
+  const sundayStart = new Date(now);
+  sundayStart.setDate(sundayStart.getDate() + ((7 - now.getDay()) % 7 || 7));
+  sundayStart.setHours(0, 0, 0, 0);
+  const sundayEnd = new Date(sundayStart);
+  sundayEnd.setHours(23, 59, 59, 999);
+
+  for (const l of lieux) {
+    if (!l.horaires) continue;
+    try {
+      const oh = new OpeningHours(l.horaires);
+      parsed.set(l.id, oh);
+      if (
+        oh.getOpenIntervals(saturdayStart, saturdayEnd).length > 0 ||
+        oh.getOpenIntervals(sundayStart, sundayEnd).length > 0
+      ) {
+        openOnWeekend.add(l.id);
+      }
+    } catch {
+      // Invalid format
+    }
+  }
+
+  return { parsed, openOnWeekend };
+};
 
 describe('filterLieux', () => {
   describe('sans filtre', () => {
@@ -223,6 +260,90 @@ describe('filterLieux', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0]?.id).toBe('1');
+    });
+  });
+
+  describe('filtre ouvert actuellement', () => {
+    it('garde les lieux ouverts à la date donnée', () => {
+      const lieux = [
+        lieu({ id: '1', horaires: 'Mo-Fr 09:00-18:00' }),
+        lieu({ id: '2', horaires: 'Sa 09:00-12:00' }),
+        lieu({ id: '3' })
+      ];
+      const ohCache = buildOpeningHoursCache(lieux);
+      const wednesdayAt10 = '2026-05-06T10:00:00.000+02:00';
+
+      const result = filterLieux(lieux, { ...emptyFilters, ouvert_actuellement: wednesdayAt10 }, undefined, ohCache);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.id).toBe('1');
+    });
+
+    it('exclut les lieux sans horaires', () => {
+      const lieux = [lieu({ id: '1' })];
+      const ohCache = buildOpeningHoursCache(lieux);
+
+      const result = filterLieux(
+        lieux,
+        { ...emptyFilters, ouvert_actuellement: '2026-05-06T10:00:00.000+02:00' },
+        undefined,
+        ohCache
+      );
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('exclut les lieux avec des horaires invalides', () => {
+      const lieux = [lieu({ id: '1', horaires: 'invalid format' })];
+      const ohCache = buildOpeningHoursCache(lieux);
+
+      const result = filterLieux(
+        lieux,
+        { ...emptyFilters, ouvert_actuellement: '2026-05-06T10:00:00.000+02:00' },
+        undefined,
+        ohCache
+      );
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('filtre ouvert le week-end', () => {
+    it('garde les lieux ouverts le samedi', () => {
+      const lieux = [lieu({ id: '1', horaires: 'Mo-Sa 09:00-18:00' }), lieu({ id: '2', horaires: 'Mo-Fr 09:00-18:00' })];
+      const ohCache = buildOpeningHoursCache(lieux);
+
+      const result = filterLieux(lieux, { ...emptyFilters, ouvert_le_week_end: true }, undefined, ohCache);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.id).toBe('1');
+    });
+
+    it('garde les lieux ouverts le dimanche', () => {
+      const lieux = [lieu({ id: '1', horaires: 'Su 10:00-16:00' }), lieu({ id: '2', horaires: 'Mo-Fr 09:00-18:00' })];
+      const ohCache = buildOpeningHoursCache(lieux);
+
+      const result = filterLieux(lieux, { ...emptyFilters, ouvert_le_week_end: true }, undefined, ohCache);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.id).toBe('1');
+    });
+
+    it('exclut les lieux sans horaires', () => {
+      const lieux = [lieu({ id: '1' })];
+      const ohCache = buildOpeningHoursCache(lieux);
+
+      const result = filterLieux(lieux, { ...emptyFilters, ouvert_le_week_end: true }, undefined, ohCache);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('ne filtre pas quand ouvert_le_week_end est undefined', () => {
+      const lieux = [lieu({ id: '1', horaires: 'Mo-Fr 09:00-18:00' })];
+
+      const result = filterLieux(lieux, { ...emptyFilters, ouvert_le_week_end: undefined });
+
+      expect(result).toHaveLength(1);
     });
   });
 

--- a/src/libraries/lieux-cache/filter-lieux.ts
+++ b/src/libraries/lieux-cache/filter-lieux.ts
@@ -64,6 +64,9 @@ const toPredicates = (filters: FiltersSchema, collectivite?: Collectivite, ohCac
     filters.ouvert_le_week_end === true && ohCache != null ? isOpenOnWeekend(ohCache) : undefined
   ].filter((p): p is LieuPredicate => p != null);
 
+export const needsOpeningHoursCache = (filters: FiltersSchema): boolean =>
+  filters.ouvert_actuellement != null || filters.ouvert_le_week_end === true;
+
 export const filterLieux = (
   lieux: LieuxRouteResponse,
   filters: FiltersSchema,

--- a/src/libraries/lieux-cache/filter-lieux.ts
+++ b/src/libraries/lieux-cache/filter-lieux.ts
@@ -1,6 +1,7 @@
 import type { Region } from '@/libraries/collectivites';
 import { regions } from '@/libraries/collectivites';
 import type { Collectivite, FiltersSchema, LieuxRouteResponse } from '@/libraries/inclusion-numerique-api';
+import type { OpeningHoursCache } from './lieux-cache';
 
 type Lieu = LieuxRouteResponse[number];
 type LieuPredicate = (lieu: Lieu) => boolean;
@@ -27,8 +28,29 @@ const TERRITOIRE_MATCHERS: Record<NonNullable<FiltersSchema['territoire_type']>,
 const containsAny = (accessor: (lieu: Lieu) => string[] | undefined, values: string[]): LieuPredicate | undefined =>
   values.length > 0 ? (lieu) => accessor(lieu)?.some((v) => values.includes(v)) ?? false : undefined;
 
-const toPredicates = (filters: FiltersSchema, collectivite?: Collectivite): LieuPredicate[] =>
+const isOpenAt =
+  (date: Date, ohCache: OpeningHoursCache): LieuPredicate =>
+  (lieu) => {
+    const oh = ohCache.parsed.get(lieu.id);
+    if (!oh) return false;
+    try {
+      return oh.getState(date);
+    } catch {
+      return false;
+    }
+  };
+
+const isOpenOnWeekend =
+  (ohCache: OpeningHoursCache): LieuPredicate =>
+  (lieu) =>
+    ohCache.openOnWeekend.has(lieu.id);
+
+const toPredicates = (filters: FiltersSchema, collectivite?: Collectivite, ohCache?: OpeningHoursCache): LieuPredicate[] =>
   [
+    collectivite != null ? codeInseeStartsWith(collectiviteCodes(collectivite)) : undefined,
+    filters.territoire_type && filters.territoires.length > 0
+      ? TERRITOIRE_MATCHERS[filters.territoire_type](filters.territoires)
+      : undefined,
     containsAny((l) => l.services, filters.services),
     containsAny((l) => l.publics_specifiquement_adresses, filters.publics_specifiquement_adresses),
     containsAny((l) => l.prise_en_charge_specifique, filters.prise_en_charge_specifique),
@@ -36,17 +58,18 @@ const toPredicates = (filters: FiltersSchema, collectivite?: Collectivite): Lieu
     containsAny((l) => l.dispositif_programmes_nationaux, filters.dispositif_programmes_nationaux),
     containsAny((l) => l.autres_formations_labels, filters.autres_formations_labels),
     filters.prise_rdv.length > 0 ? (lieu: Lieu) => lieu.prise_rdv != null : undefined,
-    filters.territoire_type && filters.territoires.length > 0
-      ? TERRITOIRE_MATCHERS[filters.territoire_type](filters.territoires)
+    filters.ouvert_actuellement != null && ohCache != null
+      ? isOpenAt(new Date(filters.ouvert_actuellement), ohCache)
       : undefined,
-    collectivite != null ? codeInseeStartsWith(collectiviteCodes(collectivite)) : undefined
+    filters.ouvert_le_week_end === true && ohCache != null ? isOpenOnWeekend(ohCache) : undefined
   ].filter((p): p is LieuPredicate => p != null);
 
 export const filterLieux = (
   lieux: LieuxRouteResponse,
   filters: FiltersSchema,
-  collectivite?: Collectivite
+  collectivite?: Collectivite,
+  ohCache?: OpeningHoursCache
 ): LieuxRouteResponse => {
-  const predicates = toPredicates(filters, collectivite);
+  const predicates = toPredicates(filters, collectivite, ohCache);
   return predicates.length > 0 ? lieux.filter((lieu) => predicates.every((p) => p(lieu))) : lieux;
 };

--- a/src/libraries/lieux-cache/index.ts
+++ b/src/libraries/lieux-cache/index.ts
@@ -1,3 +1,3 @@
-export { filterLieux } from './filter-lieux';
+export { filterLieux, needsOpeningHoursCache } from './filter-lieux';
 export type { OpeningHoursCache } from './lieux-cache';
 export { getAllLieux, getLieuById, getOpeningHoursCache, invalidateCache } from './lieux-cache';

--- a/src/libraries/lieux-cache/index.ts
+++ b/src/libraries/lieux-cache/index.ts
@@ -1,2 +1,3 @@
 export { filterLieux } from './filter-lieux';
-export { getAllLieux, getLieuById, invalidateCache } from './lieux-cache';
+export type { OpeningHoursCache } from './lieux-cache';
+export { getAllLieux, getLieuById, getOpeningHoursCache, invalidateCache } from './lieux-cache';

--- a/src/libraries/lieux-cache/lieux-cache.ts
+++ b/src/libraries/lieux-cache/lieux-cache.ts
@@ -11,15 +11,22 @@ export type OpeningHoursCache = {
 type LieuxStore = {
   all: LieuxRouteResponse;
   byId: Map<string, Lieu>;
-  openingHours: OpeningHoursCache;
 };
 
+let currentData: Promise<LieuxRouteResponse> | null = null;
 let currentStore: Promise<LieuxStore> | null = null;
+let currentOHCache: Promise<OpeningHoursCache> | null = null;
 let isRefreshing = false;
 
 const collator = new Intl.Collator('fr', { sensitivity: 'base' });
 
-const computeOpeningHours = (data: LieuxRouteResponse): OpeningHoursCache => {
+const yieldToEventLoop = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+const BATCH_SIZE = 100;
+
+const computeOpeningHours = async (data: LieuxRouteResponse): Promise<OpeningHoursCache> => {
+  await yieldToEventLoop();
+
   const parsed = new Map<string, OpeningHours>();
   const openOnWeekend = new Set<string>();
 
@@ -37,7 +44,8 @@ const computeOpeningHours = (data: LieuxRouteResponse): OpeningHoursCache => {
   const sundayEnd = new Date(sundayStart);
   sundayEnd.setHours(23, 59, 59, 999);
 
-  for (const lieu of data) {
+  for (let i = 0; i < data.length; i++) {
+    const lieu = data[i]!;
     if (!lieu.horaires) continue;
     try {
       const oh = new OpeningHours(lieu.horaires);
@@ -51,6 +59,7 @@ const computeOpeningHours = (data: LieuxRouteResponse): OpeningHoursCache => {
     } catch {
       // Invalid horaires format
     }
+    if (i % BATCH_SIZE === 0 && i > 0) await yieldToEventLoop();
   }
 
   return { parsed, openOnWeekend };
@@ -58,29 +67,49 @@ const computeOpeningHours = (data: LieuxRouteResponse): OpeningHoursCache => {
 
 const buildStore = (data: LieuxRouteResponse): LieuxStore => ({
   all: [...data].sort((a, b) => collator.compare(a.nom, b.nom)),
-  byId: new Map(data.map((lieu) => [lieu.id, lieu])),
-  openingHours: computeOpeningHours(data)
+  byId: new Map(data.map((lieu) => [lieu.id, lieu]))
 });
 
-const fetchStore = (): Promise<LieuxStore> =>
-  inclusionNumeriqueFetchApi(LIEUX_ROUTE, {}, undefined, { noCache: true }).then(([data]) => buildStore(data));
+const getData = (): Promise<LieuxRouteResponse> => {
+  if (!currentData) {
+    currentData = inclusionNumeriqueFetchApi(LIEUX_ROUTE, {}, undefined, { noCache: true })
+      .then(([data]) => data)
+      .catch((error: unknown) => {
+        currentData = null;
+        throw error;
+      });
+  }
+  return currentData;
+};
 
 const getStore = (): Promise<LieuxStore> => {
   if (!currentStore) {
-    currentStore = fetchStore().catch((error: unknown) => {
-      currentStore = null;
-      throw error;
-    });
+    currentStore = getData().then(buildStore);
   }
   return currentStore;
+};
+
+const getOHCache = (): Promise<OpeningHoursCache> => {
+  if (!currentOHCache) {
+    currentOHCache = getData()
+      .then(computeOpeningHours)
+      .catch((error: unknown) => {
+        currentOHCache = null;
+        throw error;
+      });
+  }
+  return currentOHCache;
 };
 
 export const invalidateCache = (): void => {
   if (isRefreshing) return;
   isRefreshing = true;
-  fetchStore()
-    .then((store) => {
-      currentStore = Promise.resolve(store);
+  const freshData = inclusionNumeriqueFetchApi(LIEUX_ROUTE, {}, undefined, { noCache: true }).then(([data]) => data);
+  freshData
+    .then((data) => {
+      currentData = Promise.resolve(data);
+      currentStore = Promise.resolve(buildStore(data));
+      currentOHCache = null;
     })
     .catch(() => {})
     .finally(() => {
@@ -92,4 +121,4 @@ export const getAllLieux = async (): Promise<LieuxRouteResponse> => (await getSt
 
 export const getLieuById = async (id: string): Promise<Lieu | undefined> => (await getStore()).byId.get(id);
 
-export const getOpeningHoursCache = async (): Promise<OpeningHoursCache> => (await getStore()).openingHours;
+export const getOpeningHoursCache = async (): Promise<OpeningHoursCache> => getOHCache();

--- a/src/libraries/lieux-cache/lieux-cache.ts
+++ b/src/libraries/lieux-cache/lieux-cache.ts
@@ -1,10 +1,17 @@
+import OpeningHours from 'opening_hours';
 import { inclusionNumeriqueFetchApi, LIEUX_ROUTE, type LieuxRouteResponse } from '@/libraries/inclusion-numerique-api';
 
 type Lieu = LieuxRouteResponse[number];
 
+export type OpeningHoursCache = {
+  parsed: Map<string, OpeningHours>;
+  openOnWeekend: Set<string>;
+};
+
 type LieuxStore = {
   all: LieuxRouteResponse;
   byId: Map<string, Lieu>;
+  openingHours: OpeningHoursCache;
 };
 
 let currentStore: Promise<LieuxStore> | null = null;
@@ -12,9 +19,47 @@ let isRefreshing = false;
 
 const collator = new Intl.Collator('fr', { sensitivity: 'base' });
 
+const computeOpeningHours = (data: LieuxRouteResponse): OpeningHoursCache => {
+  const parsed = new Map<string, OpeningHours>();
+  const openOnWeekend = new Set<string>();
+
+  const now = new Date();
+
+  const saturdayStart = new Date(now);
+  saturdayStart.setDate(saturdayStart.getDate() + ((6 - now.getDay() + 7) % 7 || 7));
+  saturdayStart.setHours(0, 0, 0, 0);
+  const saturdayEnd = new Date(saturdayStart);
+  saturdayEnd.setHours(23, 59, 59, 999);
+
+  const sundayStart = new Date(now);
+  sundayStart.setDate(sundayStart.getDate() + ((7 - now.getDay()) % 7 || 7));
+  sundayStart.setHours(0, 0, 0, 0);
+  const sundayEnd = new Date(sundayStart);
+  sundayEnd.setHours(23, 59, 59, 999);
+
+  for (const lieu of data) {
+    if (!lieu.horaires) continue;
+    try {
+      const oh = new OpeningHours(lieu.horaires);
+      parsed.set(lieu.id, oh);
+      if (
+        oh.getOpenIntervals(saturdayStart, saturdayEnd).length > 0 ||
+        oh.getOpenIntervals(sundayStart, sundayEnd).length > 0
+      ) {
+        openOnWeekend.add(lieu.id);
+      }
+    } catch {
+      // Invalid horaires format
+    }
+  }
+
+  return { parsed, openOnWeekend };
+};
+
 const buildStore = (data: LieuxRouteResponse): LieuxStore => ({
   all: [...data].sort((a, b) => collator.compare(a.nom, b.nom)),
-  byId: new Map(data.map((lieu) => [lieu.id, lieu]))
+  byId: new Map(data.map((lieu) => [lieu.id, lieu])),
+  openingHours: computeOpeningHours(data)
 });
 
 const fetchStore = (): Promise<LieuxStore> =>
@@ -46,3 +91,5 @@ export const invalidateCache = (): void => {
 export const getAllLieux = async (): Promise<LieuxRouteResponse> => (await getStore()).all;
 
 export const getLieuById = async (id: string): Promise<Lieu | undefined> => (await getStore()).byId.get(id);
+
+export const getOpeningHoursCache = async (): Promise<OpeningHoursCache> => (await getStore()).openingHours;


### PR DESCRIPTION
Pre-parse opening hours at cache build time and reuse the same instance for weekend checks, avoiding duplicate parsing of 8k+ horaires strings.