### PR TITLE
ci: upgrade to pnpm 11 and setup Node before pnpm

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@v5
       with:
-        version: '10'
+        version: '11'
     - name: Set up Node.js
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/validate-feature-branch.yml
+++ b/.github/workflows/validate-feature-branch.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: '10'
+          version: '11'
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
pnpm 11 requires Node >= 22.13 for node:sqlite support. Swap setup order so Node is available before pnpm runs.