### PR TITLE
ci: upgrade to pnpm 11 and setup Node before pnpm

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,15 +4,14 @@ description: 'Install pnpm, Node.js and dependencies'
 runs:
   using: 'composite'
   steps:
-    - name: Install pnpm
-      uses: pnpm/action-setup@v5
-      with:
-        version: '11'
     - name: Set up Node.js
       uses: actions/setup-node@v6
       with:
         node-version: '22'
-        cache: 'pnpm'
+    - name: Install pnpm
+      uses: pnpm/action-setup@v5
+      with:
+        version: '11'
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
       shell: bash

--- a/.github/workflows/validate-feature-branch.yml
+++ b/.github/workflows/validate-feature-branch.yml
@@ -156,15 +156,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: '11'
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '22'
-          cache: 'pnpm'
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: '11'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         working-directory: infrastructure


### PR DESCRIPTION
pnpm 11 requires Node >= 22.13 for node:sqlite support. Swap setup order so Node is available before pnpm runs.