### PR TITLE
ci: fix Node/pnpm setup order in deploy and release workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,20 +15,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install app dependencies
-        uses: pnpm/action-setup@v5
-        with:
-          version: latest
-
-      - name: Install infrastructure dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-        working-directory: infrastructure
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: latest
-          cache: 'pnpm'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: '11'
+
+      - name: Install infrastructure dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        working-directory: infrastructure
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -19,16 +19,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: latest
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: latest
-          cache: 'pnpm'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: '11'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
@@ -59,17 +58,16 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: latest
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: latest
-          cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: '11'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
Setup Node before pnpm so pnpm 11 has access to node:sqlite. Pin pnpm to version 11 instead of latest for reproducibility.