### PR TITLE
perf: lazy OpeningHours parsing and two-pass filtering

### DIFF
--- a/src/features/collectivites-territoriales/abilities/stats-query/stats.ts
+++ b/src/features/collectivites-territoriales/abilities/stats-query/stats.ts
@@ -6,7 +6,7 @@ import {
   type Region
 } from '@/libraries/collectivites';
 import type { FiltersSchema } from '@/libraries/inclusion-numerique-api';
-import { filterLieux, getAllLieux, getOpeningHoursCache, needsOpeningHoursCache } from '@/libraries/lieux-cache';
+import { filterLieux, getAllLieux, getOpeningHoursCache } from '@/libraries/lieux-cache';
 import { aggregateByDepartement } from './aggregate-by-departement';
 
 export type RegionWithCount = Region & { nombreLieux: number };
@@ -18,10 +18,7 @@ const toRegionTotalCount = (departementsAvecTotaux: DepartementWithCount[]) => (
 export type AllStats = { regions: RegionWithCount[]; departements: DepartementWithCount[] };
 
 export const fetchAllStats = async (filters: FiltersSchema): Promise<AllStats> => {
-  const [allLieux, ohCache] = await Promise.all([
-    getAllLieux(),
-    needsOpeningHoursCache(filters) ? getOpeningHoursCache() : undefined
-  ]);
+  const [allLieux, ohCache] = await Promise.all([getAllLieux(), getOpeningHoursCache()]);
   const filtered = filterLieux(allLieux, filters, undefined, ohCache);
   const codeInsees = filtered.map((lieu) => lieu.adresse.code_insee).filter(Boolean);
   const countsByDept = aggregateByDepartement(codeInsees);

--- a/src/features/lieux-inclusion-numerique/abilities/count/count-lieux.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/count/count-lieux.ts
@@ -1,12 +1,9 @@
 import type { Collectivite, FiltersSchema } from '@/libraries/inclusion-numerique-api';
-import { filterLieux, getAllLieux, getOpeningHoursCache, needsOpeningHoursCache } from '@/libraries/lieux-cache';
+import { filterLieux, getAllLieux, getOpeningHoursCache } from '@/libraries/lieux-cache';
 
 export const countLieux =
   (collectivite?: Collectivite) =>
   async (filters: FiltersSchema): Promise<number> => {
-    const [allLieux, ohCache] = await Promise.all([
-      getAllLieux(),
-      needsOpeningHoursCache(filters) ? getOpeningHoursCache() : undefined
-    ]);
+    const [allLieux, ohCache] = await Promise.all([getAllLieux(), getOpeningHoursCache()]);
     return filterLieux(allLieux, filters, collectivite, ohCache).length;
   };

--- a/src/features/lieux-inclusion-numerique/abilities/export/query/fetch-all-lieux.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/export/query/fetch-all-lieux.ts
@@ -1,12 +1,9 @@
 import type { Collectivite, FiltersSchema, LieuxRouteResponse } from '@/libraries/inclusion-numerique-api';
-import { filterLieux, getAllLieux, getOpeningHoursCache, needsOpeningHoursCache } from '@/libraries/lieux-cache';
+import { filterLieux, getAllLieux, getOpeningHoursCache } from '@/libraries/lieux-cache';
 
 export const fetchAllLieux =
   (collectivite?: Collectivite) =>
   async (filters: FiltersSchema): Promise<LieuxRouteResponse> => {
-    const [allLieux, ohCache] = await Promise.all([
-      getAllLieux(),
-      needsOpeningHoursCache(filters) ? getOpeningHoursCache() : undefined
-    ]);
+    const [allLieux, ohCache] = await Promise.all([getAllLieux(), getOpeningHoursCache()]);
     return filterLieux(allLieux, filters, collectivite, ohCache);
   };

--- a/src/features/lieux-inclusion-numerique/abilities/list-view/query/fetch-lieux.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/list-view/query/fetch-lieux.ts
@@ -4,7 +4,7 @@ import {
   LIEU_LIST_FIELDS,
   type LieuxRouteResponse
 } from '@/libraries/inclusion-numerique-api';
-import { filterLieux, getAllLieux, getOpeningHoursCache, needsOpeningHoursCache } from '@/libraries/lieux-cache';
+import { filterLieux, getAllLieux, getOpeningHoursCache } from '@/libraries/lieux-cache';
 
 type PaginationParams = {
   page: number;
@@ -22,10 +22,7 @@ const pick = (lieu: LieuxRouteResponse[number]): LieuxRouteResponse[number] =>
 export const fetchLieux =
   (collectivite?: Collectivite) =>
   async (filters: FiltersSchema, { page, limit }: PaginationParams): Promise<LieuxWithTotal> => {
-    const [allLieux, ohCache] = await Promise.all([
-      getAllLieux(),
-      needsOpeningHoursCache(filters) ? getOpeningHoursCache() : undefined
-    ]);
+    const [allLieux, ohCache] = await Promise.all([getAllLieux(), getOpeningHoursCache()]);
     const filtered = filterLieux(allLieux, filters, collectivite, ohCache);
     return { lieux: filtered.slice((page - 1) * limit, page * limit).map(pick), total: filtered.length };
   };

--- a/src/features/lieux-inclusion-numerique/abilities/map-view/query/fetch-lieux-for-chunk.server.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/map-view/query/fetch-lieux-for-chunk.server.ts
@@ -1,14 +1,11 @@
 import type { BBox } from 'geojson';
 import type { FiltersSchema } from '@/libraries/inclusion-numerique-api';
-import { filterLieux, getAllLieux, getOpeningHoursCache, needsOpeningHoursCache } from '@/libraries/lieux-cache';
+import { filterLieux, getAllLieux, getOpeningHoursCache } from '@/libraries/lieux-cache';
 import { MAP_CHUNK_OPTIONS, mapChunk, type Position2D } from '@/libraries/map';
 
 export const fetchLieuxForChunkServer = async (position: Position2D, filters: FiltersSchema) => {
   const [minLon, minLat, maxLon, maxLat]: BBox = mapChunk(position, MAP_CHUNK_OPTIONS);
-  const [allLieux, ohCache] = await Promise.all([
-    getAllLieux(),
-    needsOpeningHoursCache(filters) ? getOpeningHoursCache() : undefined
-  ]);
+  const [allLieux, ohCache] = await Promise.all([getAllLieux(), getOpeningHoursCache()]);
 
   const chunkLieux = allLieux.filter(
     (lieu) =>

--- a/src/features/lieux-inclusion-numerique/abilities/map-view/query/lieux.stream.ts
+++ b/src/features/lieux-inclusion-numerique/abilities/map-view/query/lieux.stream.ts
@@ -58,31 +58,29 @@ export const lieux$ = (
 ): Observable<{
   features: (PointFeature<Lieu> | ClusterFeature<ClusterProperties>)[];
 }> =>
-  combineLatest([zoom$, boundingBox$, searchParams$])
-    .pipe(
-      distinctUntilChanged(
-        ([prevZoom, prevBbox, prevParams], [nextZoom, nextBbox, nextParams]) =>
-          prevZoom === nextZoom &&
-          prevBbox[0] === nextBbox[0] &&
-          prevBbox[1] === nextBbox[1] &&
-          prevBbox[2] === nextBbox[2] &&
-          prevBbox[3] === nextBbox[3] &&
-          prevParams.toString() === nextParams.toString()
-      ),
-      filter(([zoom]) => zoom > 9),
-      switchMap(([zoom, boundingBox, searchParams]) => {
-        const centers: Position2D[] = splitBondingBox(boundingBox, MAP_CHUNK_OPTIONS).map(boundingBoxCenter);
+  combineLatest([zoom$, boundingBox$, searchParams$]).pipe(
+    distinctUntilChanged(
+      ([prevZoom, prevBbox, prevParams], [nextZoom, nextBbox, nextParams]) =>
+        prevZoom === nextZoom &&
+        prevBbox[0] === nextBbox[0] &&
+        prevBbox[1] === nextBbox[1] &&
+        prevBbox[2] === nextBbox[2] &&
+        prevBbox[3] === nextBbox[3] &&
+        prevParams.toString() === nextParams.toString()
+    ),
+    filter(([zoom]) => zoom > 9),
+    switchMap(([zoom, boundingBox, searchParams]) => {
+      const centers: Position2D[] = splitBondingBox(boundingBox, MAP_CHUNK_OPTIONS).map(boundingBoxCenter);
 
-        return centers.length === 0
-          ? of({ features: [] })
-          : resolvePositions(
-              centers.reduce<PositionsWithCache>(toPositionsWithCache, EMPTY_POSITIONS_WITH_CACHE),
-              searchParams
-            ).pipe(
-              map((lieux: Lieu[]) => ({
-                features: supercluster.load(lieux.map(toPointFeature)).getClusters(boundingBox, zoom)
-              }))
-            );
-      })
-    )
-    .pipe(filter(({ features }) => features.length > 0));
+      return centers.length === 0
+        ? of({ features: [] })
+        : resolvePositions(
+            centers.reduce<PositionsWithCache>(toPositionsWithCache, EMPTY_POSITIONS_WITH_CACHE),
+            searchParams
+          ).pipe(
+            map((lieux: Lieu[]) => ({
+              features: supercluster.load(lieux.map(toPointFeature)).getClusters(boundingBox, zoom)
+            }))
+          );
+    })
+  );

--- a/src/libraries/lieux-cache/filter-lieux.spec.ts
+++ b/src/libraries/lieux-cache/filter-lieux.spec.ts
@@ -1,8 +1,7 @@
-import OpeningHours from 'opening_hours';
 import { describe, expect, it } from 'vitest';
 import type { FiltersSchema, LieuxRouteResponse } from '@/libraries/inclusion-numerique-api';
 import { filterLieux } from './filter-lieux';
-import type { OpeningHoursCache } from './lieux-cache';
+import { OpeningHoursCache } from './opening-hours-cache';
 
 const emptyFilters: FiltersSchema = {
   services: [],
@@ -26,41 +25,6 @@ const lieu = (overrides: Partial<LieuxRouteResponse[number]> = {}): LieuxRouteRe
     services: [],
     ...overrides
   }) as LieuxRouteResponse[number];
-
-const buildOpeningHoursCache = (lieux: LieuxRouteResponse): OpeningHoursCache => {
-  const parsed = new Map<string, OpeningHours>();
-  const openOnWeekend = new Set<string>();
-
-  const now = new Date();
-  const saturdayStart = new Date(now);
-  saturdayStart.setDate(saturdayStart.getDate() + ((6 - now.getDay() + 7) % 7 || 7));
-  saturdayStart.setHours(0, 0, 0, 0);
-  const saturdayEnd = new Date(saturdayStart);
-  saturdayEnd.setHours(23, 59, 59, 999);
-  const sundayStart = new Date(now);
-  sundayStart.setDate(sundayStart.getDate() + ((7 - now.getDay()) % 7 || 7));
-  sundayStart.setHours(0, 0, 0, 0);
-  const sundayEnd = new Date(sundayStart);
-  sundayEnd.setHours(23, 59, 59, 999);
-
-  for (const l of lieux) {
-    if (!l.horaires) continue;
-    try {
-      const oh = new OpeningHours(l.horaires);
-      parsed.set(l.id, oh);
-      if (
-        oh.getOpenIntervals(saturdayStart, saturdayEnd).length > 0 ||
-        oh.getOpenIntervals(sundayStart, sundayEnd).length > 0
-      ) {
-        openOnWeekend.add(l.id);
-      }
-    } catch {
-      // Invalid format
-    }
-  }
-
-  return { parsed, openOnWeekend };
-};
 
 describe('filterLieux', () => {
   describe('sans filtre', () => {
@@ -270,7 +234,7 @@ describe('filterLieux', () => {
         lieu({ id: '2', horaires: 'Sa 09:00-12:00' }),
         lieu({ id: '3' })
       ];
-      const ohCache = buildOpeningHoursCache(lieux);
+      const ohCache = new OpeningHoursCache(lieux);
       const wednesdayAt12UTC = '2026-05-06T12:00:00.000Z';
 
       const result = filterLieux(lieux, { ...emptyFilters, ouvert_actuellement: wednesdayAt12UTC }, undefined, ohCache);
@@ -281,7 +245,7 @@ describe('filterLieux', () => {
 
     it('exclut les lieux sans horaires', () => {
       const lieux = [lieu({ id: '1' })];
-      const ohCache = buildOpeningHoursCache(lieux);
+      const ohCache = new OpeningHoursCache(lieux);
 
       const result = filterLieux(
         lieux,
@@ -295,7 +259,7 @@ describe('filterLieux', () => {
 
     it('exclut les lieux avec des horaires invalides', () => {
       const lieux = [lieu({ id: '1', horaires: 'invalid format' })];
-      const ohCache = buildOpeningHoursCache(lieux);
+      const ohCache = new OpeningHoursCache(lieux);
 
       const result = filterLieux(
         lieux,
@@ -311,7 +275,7 @@ describe('filterLieux', () => {
   describe('filtre ouvert le week-end', () => {
     it('garde les lieux ouverts le samedi', () => {
       const lieux = [lieu({ id: '1', horaires: 'Mo-Sa 09:00-18:00' }), lieu({ id: '2', horaires: 'Mo-Fr 09:00-18:00' })];
-      const ohCache = buildOpeningHoursCache(lieux);
+      const ohCache = new OpeningHoursCache(lieux);
 
       const result = filterLieux(lieux, { ...emptyFilters, ouvert_le_week_end: true }, undefined, ohCache);
 
@@ -321,7 +285,7 @@ describe('filterLieux', () => {
 
     it('garde les lieux ouverts le dimanche', () => {
       const lieux = [lieu({ id: '1', horaires: 'Su 10:00-16:00' }), lieu({ id: '2', horaires: 'Mo-Fr 09:00-18:00' })];
-      const ohCache = buildOpeningHoursCache(lieux);
+      const ohCache = new OpeningHoursCache(lieux);
 
       const result = filterLieux(lieux, { ...emptyFilters, ouvert_le_week_end: true }, undefined, ohCache);
 
@@ -331,7 +295,7 @@ describe('filterLieux', () => {
 
     it('exclut les lieux sans horaires', () => {
       const lieux = [lieu({ id: '1' })];
-      const ohCache = buildOpeningHoursCache(lieux);
+      const ohCache = new OpeningHoursCache(lieux);
 
       const result = filterLieux(lieux, { ...emptyFilters, ouvert_le_week_end: true }, undefined, ohCache);
 

--- a/src/libraries/lieux-cache/filter-lieux.ts
+++ b/src/libraries/lieux-cache/filter-lieux.ts
@@ -1,7 +1,7 @@
 import type { Region } from '@/libraries/collectivites';
 import { regions } from '@/libraries/collectivites';
 import type { Collectivite, FiltersSchema, LieuxRouteResponse } from '@/libraries/inclusion-numerique-api';
-import type { OpeningHoursCache } from './lieux-cache';
+import type { OpeningHoursCache } from './opening-hours-cache';
 
 type Lieu = LieuxRouteResponse[number];
 type LieuPredicate = (lieu: Lieu) => boolean;
@@ -31,7 +31,7 @@ const containsAny = (accessor: (lieu: Lieu) => string[] | undefined, values: str
 const isOpenAt =
   (date: Date, ohCache: OpeningHoursCache): LieuPredicate =>
   (lieu) => {
-    const oh = ohCache.parsed.get(lieu.id);
+    const oh = ohCache.get(lieu.id);
     if (!oh) return false;
     try {
       return oh.getState(date);
@@ -40,12 +40,29 @@ const isOpenAt =
     }
   };
 
-const isOpenOnWeekend =
-  (ohCache: OpeningHoursCache): LieuPredicate =>
-  (lieu) =>
-    ohCache.openOnWeekend.has(lieu.id);
+const isOpenOnWeekend = (ohCache: OpeningHoursCache): LieuPredicate => {
+  const now = new Date();
 
-const toPredicates = (filters: FiltersSchema, collectivite?: Collectivite, ohCache?: OpeningHoursCache): LieuPredicate[] =>
+  const saturdayStart = new Date(now);
+  saturdayStart.setDate(saturdayStart.getDate() + ((6 - now.getDay() + 7) % 7 || 7));
+  saturdayStart.setHours(0, 0, 0, 0);
+  const saturdayEnd = new Date(saturdayStart);
+  saturdayEnd.setHours(23, 59, 59, 999);
+
+  const sundayStart = new Date(now);
+  sundayStart.setDate(sundayStart.getDate() + ((7 - now.getDay()) % 7 || 7));
+  sundayStart.setHours(0, 0, 0, 0);
+  const sundayEnd = new Date(sundayStart);
+  sundayEnd.setHours(23, 59, 59, 999);
+
+  return (lieu) => {
+    const oh = ohCache.get(lieu.id);
+    if (!oh) return false;
+    return oh.getOpenIntervals(saturdayStart, saturdayEnd).length > 0 || oh.getOpenIntervals(sundayStart, sundayEnd).length > 0;
+  };
+};
+
+const toFastPredicates = (filters: FiltersSchema, collectivite?: Collectivite): LieuPredicate[] =>
   [
     collectivite != null ? codeInseeStartsWith(collectiviteCodes(collectivite)) : undefined,
     filters.territoire_type && filters.territoires.length > 0
@@ -57,15 +74,16 @@ const toPredicates = (filters: FiltersSchema, collectivite?: Collectivite, ohCac
     containsAny((l) => l.frais_a_charge, filters.frais_a_charge),
     containsAny((l) => l.dispositif_programmes_nationaux, filters.dispositif_programmes_nationaux),
     containsAny((l) => l.autres_formations_labels, filters.autres_formations_labels),
-    filters.prise_rdv.length > 0 ? (lieu: Lieu) => lieu.prise_rdv != null : undefined,
+    filters.prise_rdv.length > 0 ? (lieu: Lieu) => lieu.prise_rdv != null : undefined
+  ].filter((p): p is LieuPredicate => p != null);
+
+const toOHPredicates = (filters: FiltersSchema, ohCache?: OpeningHoursCache): LieuPredicate[] =>
+  [
     filters.ouvert_actuellement != null && ohCache != null
       ? isOpenAt(new Date(filters.ouvert_actuellement), ohCache)
       : undefined,
     filters.ouvert_le_week_end === true && ohCache != null ? isOpenOnWeekend(ohCache) : undefined
   ].filter((p): p is LieuPredicate => p != null);
-
-export const needsOpeningHoursCache = (filters: FiltersSchema): boolean =>
-  filters.ouvert_actuellement != null || filters.ouvert_le_week_end === true;
 
 export const filterLieux = (
   lieux: LieuxRouteResponse,
@@ -73,6 +91,10 @@ export const filterLieux = (
   collectivite?: Collectivite,
   ohCache?: OpeningHoursCache
 ): LieuxRouteResponse => {
-  const predicates = toPredicates(filters, collectivite, ohCache);
-  return predicates.length > 0 ? lieux.filter((lieu) => predicates.every((p) => p(lieu))) : lieux;
+  const fastPredicates = toFastPredicates(filters, collectivite);
+  const ohPredicates = toOHPredicates(filters, ohCache);
+
+  const afterFast = fastPredicates.length > 0 ? lieux.filter((lieu) => fastPredicates.every((p) => p(lieu))) : lieux;
+
+  return ohPredicates.length > 0 ? afterFast.filter((lieu) => ohPredicates.every((p) => p(lieu))) : afterFast;
 };

--- a/src/libraries/lieux-cache/index.ts
+++ b/src/libraries/lieux-cache/index.ts
@@ -1,3 +1,3 @@
-export { filterLieux, needsOpeningHoursCache } from './filter-lieux';
-export type { OpeningHoursCache } from './lieux-cache';
+export { filterLieux } from './filter-lieux';
 export { getAllLieux, getLieuById, getOpeningHoursCache, invalidateCache } from './lieux-cache';
+export { OpeningHoursCache } from './opening-hours-cache';

--- a/src/libraries/lieux-cache/lieux-cache.ts
+++ b/src/libraries/lieux-cache/lieux-cache.ts
@@ -1,73 +1,24 @@
-import OpeningHours from 'opening_hours';
 import { inclusionNumeriqueFetchApi, LIEUX_ROUTE, type LieuxRouteResponse } from '@/libraries/inclusion-numerique-api';
+import { OpeningHoursCache } from './opening-hours-cache';
 
 type Lieu = LieuxRouteResponse[number];
-
-export type OpeningHoursCache = {
-  parsed: Map<string, OpeningHours>;
-  openOnWeekend: Set<string>;
-};
 
 type LieuxStore = {
   all: LieuxRouteResponse;
   byId: Map<string, Lieu>;
+  openingHours: OpeningHoursCache;
 };
 
 let currentData: Promise<LieuxRouteResponse> | null = null;
 let currentStore: Promise<LieuxStore> | null = null;
-let currentOHCache: Promise<OpeningHoursCache> | null = null;
 let isRefreshing = false;
 
 const collator = new Intl.Collator('fr', { sensitivity: 'base' });
 
-const yieldToEventLoop = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
-
-const BATCH_SIZE = 100;
-
-const computeOpeningHours = async (data: LieuxRouteResponse): Promise<OpeningHoursCache> => {
-  await yieldToEventLoop();
-
-  const parsed = new Map<string, OpeningHours>();
-  const openOnWeekend = new Set<string>();
-
-  const now = new Date();
-
-  const saturdayStart = new Date(now);
-  saturdayStart.setDate(saturdayStart.getDate() + ((6 - now.getDay() + 7) % 7 || 7));
-  saturdayStart.setHours(0, 0, 0, 0);
-  const saturdayEnd = new Date(saturdayStart);
-  saturdayEnd.setHours(23, 59, 59, 999);
-
-  const sundayStart = new Date(now);
-  sundayStart.setDate(sundayStart.getDate() + ((7 - now.getDay()) % 7 || 7));
-  sundayStart.setHours(0, 0, 0, 0);
-  const sundayEnd = new Date(sundayStart);
-  sundayEnd.setHours(23, 59, 59, 999);
-
-  for (let i = 0; i < data.length; i++) {
-    const lieu = data[i]!;
-    if (!lieu.horaires) continue;
-    try {
-      const oh = new OpeningHours(lieu.horaires);
-      parsed.set(lieu.id, oh);
-      if (
-        oh.getOpenIntervals(saturdayStart, saturdayEnd).length > 0 ||
-        oh.getOpenIntervals(sundayStart, sundayEnd).length > 0
-      ) {
-        openOnWeekend.add(lieu.id);
-      }
-    } catch {
-      // Invalid horaires format
-    }
-    if (i % BATCH_SIZE === 0 && i > 0) await yieldToEventLoop();
-  }
-
-  return { parsed, openOnWeekend };
-};
-
 const buildStore = (data: LieuxRouteResponse): LieuxStore => ({
   all: [...data].sort((a, b) => collator.compare(a.nom, b.nom)),
-  byId: new Map(data.map((lieu) => [lieu.id, lieu]))
+  byId: new Map(data.map((lieu) => [lieu.id, lieu])),
+  openingHours: new OpeningHoursCache(data)
 });
 
 const getData = (): Promise<LieuxRouteResponse> => {
@@ -89,18 +40,6 @@ const getStore = (): Promise<LieuxStore> => {
   return currentStore;
 };
 
-const getOHCache = (): Promise<OpeningHoursCache> => {
-  if (!currentOHCache) {
-    currentOHCache = getData()
-      .then(computeOpeningHours)
-      .catch((error: unknown) => {
-        currentOHCache = null;
-        throw error;
-      });
-  }
-  return currentOHCache;
-};
-
 export const invalidateCache = (): void => {
   if (isRefreshing) return;
   isRefreshing = true;
@@ -109,7 +48,6 @@ export const invalidateCache = (): void => {
     .then((data) => {
       currentData = Promise.resolve(data);
       currentStore = Promise.resolve(buildStore(data));
-      currentOHCache = null;
     })
     .catch(() => {})
     .finally(() => {
@@ -121,4 +59,4 @@ export const getAllLieux = async (): Promise<LieuxRouteResponse> => (await getSt
 
 export const getLieuById = async (id: string): Promise<Lieu | undefined> => (await getStore()).byId.get(id);
 
-export const getOpeningHoursCache = async (): Promise<OpeningHoursCache> => getOHCache();
+export const getOpeningHoursCache = async (): Promise<OpeningHoursCache> => (await getStore()).openingHours;

--- a/src/libraries/lieux-cache/opening-hours-cache.ts
+++ b/src/libraries/lieux-cache/opening-hours-cache.ts
@@ -1,0 +1,30 @@
+import OpeningHours from 'opening_hours';
+import type { LieuxRouteResponse } from '@/libraries/inclusion-numerique-api';
+
+export class OpeningHoursCache {
+  private readonly raw: Map<string, string>;
+  private readonly parsed = new Map<string, OpeningHours>();
+  private readonly invalid = new Set<string>();
+
+  constructor(data: LieuxRouteResponse) {
+    this.raw = new Map();
+    for (const lieu of data) {
+      if (lieu.horaires) this.raw.set(lieu.id, lieu.horaires);
+    }
+  }
+
+  get(id: string): OpeningHours | undefined {
+    if (this.parsed.has(id)) return this.parsed.get(id);
+    if (this.invalid.has(id)) return undefined;
+    const horaires = this.raw.get(id);
+    if (!horaires) return undefined;
+    try {
+      const oh = new OpeningHours(horaires);
+      this.parsed.set(id, oh);
+      return oh;
+    } catch {
+      this.invalid.add(id);
+      return undefined;
+    }
+  }
+}


### PR DESCRIPTION
- Extract OpeningHoursCache class with lazy per-lieu parsing instead of upfront parsing of all 15k horaires strings
- Split filterLieux into fast predicates (applied first to reduce set) and OH predicates (applied last on reduced set only)
- Compute weekend open intervals on-the-fly instead of pre-computed Set
- Fix map not clearing markers when OH filter returns 0 results