### PR TITLE
fix: web component bundle crash (nodemailer) + Pulumi deploy rate limit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,7 @@ jobs:
           stack-name: marc-gavanier/cartographie/prod
           work-dir: infrastructure
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
           SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 import { MatomoTracker } from '@/libraries/analytics';
 import { Toaster } from '@/libraries/ui/blocks/toaster';
 import { ThemeProvider } from '@/libraries/ui/theme/providers';
-import { ConfigProvider } from '@/shared/injection';
+import { ConfigProvider } from '@/shared/injection/providers/config.provider';
 
 const RootLayout = ({ children }: { children: ReactNode }) => (
   <html lang='fr' suppressHydrationWarning>

--- a/src/shared/injection/index.ts
+++ b/src/shared/injection/index.ts
@@ -3,4 +3,3 @@ export { MAP_CONFIG, type MapConfig } from './keys/map-config.key';
 export { type MapPosition, mapPositionSchema } from './keys/map-position.schema';
 export { SITE_URL } from './keys/site-url.key';
 export { TERRITOIRE_FILTER, type TerritoireFilter, type TerritoireType } from './keys/territoire-filter.key';
-export { ConfigProvider } from './providers/config.provider';


### PR DESCRIPTION
## Summary

Two independent fixes:

- **Web component black screen** — the `@/shared/injection` barrel re-exported `ConfigProvider`, which transitively imports the Next server action and `nodemailer`. Since many WC-reachable modules import keys from that barrel, `nodemailer` was bundled into the web component and crashed at load in the browser (`class heritage is not an object or null`). Removed the re-export from the shared barrel; the Next root layout now imports `ConfigProvider` from its module directly.
- **Deploy pipeline failures** — the Pulumi Scaleway provider is downloaded from `github://pulumiverse` release assets. Without `GITHUB_TOKEN`, those downloads are anonymous and hit GitHub's 60 req/h limit, failing the deploy with a 403 once enough runs accumulate. Pass `GITHUB_TOKEN` to the deploy step to authenticate plugin downloads.

## Verification

- `pnpm build:wc` clean; `nodemailer`/SMTP refs absent from both `cartographie.es.js` and `cartographie.umd.js`
- Web component renders locally (black screen gone)
- `tsc --noEmit` green

## Test plan

- [ ] CI "Validate feature branch" green on this branch
- [ ] After merge: "Build and deploy" succeeds (no 403 on the Scaleway plugin download)
- [ ] After merge: new npm release embeds the fixed WC bundle; integrators no longer see the black screen