### PR TITLE
feat(lieux-cache): instrument store instances to diagnose stale fiches

### DIFF
--- a/src/app/(main)/(full-page)/(regions)/[region]/[departement]/lieux/[id]/page.tsx
+++ b/src/app/(main)/(full-page)/(regions)/[region]/[departement]/lieux/[id]/page.tsx
@@ -3,6 +3,7 @@ import { withParams, withRequired, withSearchParams } from '@arckit/nextjs/page/
 import type { Metadata } from 'next';
 import { sendContactMessageAction } from '@/app/_actions/contact/send-contact-message.action';
 import { pageBuilder, withClientBinder } from '@/configuration/nextjs';
+import { logger } from '@/configuration/telemetry/logger/server';
 import { appendCollectivites } from '@/features/collectivites-territoriales';
 import { withDepartement, withRegion } from '@/features/collectivites-territoriales/middlewares/page';
 import { ContactAction } from '@/features/contact';
@@ -10,6 +11,7 @@ import { SEND_CONTACT_MESSAGE_ACTION } from '@/features/contact/abilities/send-m
 import { FicheLieuPage } from '@/features/lieux-inclusion-numerique';
 import { fetchLieuDetails } from '@/features/lieux-inclusion-numerique/abilities/detail-view/query/fetch-lieu-details';
 import { toLieuDetails } from '@/libraries/inclusion-numerique-api/transfer/to-lieu-details';
+import { getCacheStatus } from '@/libraries/lieux-cache';
 import { hrefWithSearchParams } from '@/libraries/nextjs';
 import { appPageTitle } from '@/libraries/utils';
 import { CONTACT_ACTION } from '@/shared/injection/keys/contact-action.key';
@@ -20,7 +22,24 @@ type PageProps = {
 };
 
 export const generateMetadata = async ({ params }: PageProps): Promise<Metadata> => {
-  const lieu = await fetchLieuDetails((await params).id);
+  const { id } = await params;
+  const lieu = await fetchLieuDetails(id);
+
+  const status = getCacheStatus();
+  logger.log({
+    level: 'info',
+    event: 'lieu-detail.render',
+    attributes: {
+      'lieu.id': decodeURIComponent(id),
+      'lieu.found': lieu != null,
+      'cache.instance_id': status.instanceId,
+      'cache.pid': status.pid,
+      'cache.built_at': status.storeBuiltAt ?? '',
+      'cache.refreshed_at': status.lastRefreshedAt ?? '',
+      'cache.build_count': status.buildCount,
+      'cache.size': status.size ?? 0
+    }
+  });
 
   return {
     title: appPageTitle('Fiche du lieu', lieu?.nom ?? 'Lieu introuvable'),

--- a/src/app/api/cache/reset/route.ts
+++ b/src/app/api/cache/reset/route.ts
@@ -1,13 +1,15 @@
 import { routeBuilder } from '@arckit/nextjs/route';
 import { revalidateTag } from 'next/cache';
 import { errorReporter } from '@/configuration/telemetry/error-reporter';
+import { logger } from '@/configuration/telemetry/logger/server';
 import { serverEnv } from '@/env.server';
-import { invalidateCache } from '@/libraries/lieux-cache';
+import { getCacheStatus, invalidateCache } from '@/libraries/lieux-cache';
 import { withStaticBearerAuth } from '@/libraries/nextjs/route/middlewares/with-static-bearer-auth';
 
 export const POST = routeBuilder()
   .use(withStaticBearerAuth(serverEnv.CACHE_RESET_TOKEN))
   .handle(async () => {
+    const before = getCacheStatus();
     try {
       await invalidateCache();
     } catch (error) {
@@ -15,8 +17,28 @@ export const POST = routeBuilder()
         error: error instanceof Error ? error : new Error(String(error)),
         attributes: { 'cache.operation': 'invalidate' }
       });
+      logger.log({
+        level: 'error',
+        event: 'lieux-cache.reset',
+        error: error instanceof Error ? error : new Error(String(error)),
+        attributes: { 'cache.instance_id': before.instanceId, 'cache.pid': before.pid, 'cache.outcome': 'failed' }
+      });
       return new Response('cache reset failed', { status: 503 });
     }
+    const after = getCacheStatus();
+    logger.log({
+      level: 'info',
+      event: 'lieux-cache.reset',
+      attributes: {
+        'cache.instance_id': after.instanceId,
+        'cache.pid': after.pid,
+        'cache.outcome': 'ok',
+        'cache.size_before': before.size ?? 0,
+        'cache.size_after': after.size ?? 0,
+        'cache.build_count': after.buildCount,
+        'cache.refreshed_at': after.lastRefreshedAt ?? ''
+      }
+    });
     revalidateTag('lieux', { expire: 0 });
-    return Response.json({ status: 'cache reset' });
+    return Response.json({ status: 'cache reset', cache: after });
   });

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -5,9 +5,22 @@ export { onRequestError } from '@/configuration/telemetry/error-reporter/server'
 export async function register() {
   registerErrorReporter();
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    const { getAllLieux } = await import('@/libraries/lieux-cache');
+    const { getAllLieux, getCacheStatus } = await import('@/libraries/lieux-cache');
     try {
       await getAllLieux();
+      const { logger } = await import('@/configuration/telemetry/logger/server');
+      const status = getCacheStatus();
+      logger.log({
+        level: 'info',
+        event: 'lieux-cache.warm',
+        attributes: {
+          'cache.instance_id': status.instanceId,
+          'cache.pid': status.pid,
+          'cache.size': status.size ?? 0,
+          'cache.built_at': status.storeBuiltAt ?? '',
+          'cache.build_count': status.buildCount
+        }
+      });
     } catch (error) {
       const { errorReporter } = await import('@/configuration/telemetry/error-reporter');
       errorReporter.captureException({

--- a/src/libraries/lieux-cache/index.ts
+++ b/src/libraries/lieux-cache/index.ts
@@ -1,3 +1,4 @@
 export { filterLieux } from './filter-lieux';
+export type { CacheStatus } from './lieux-cache';
 export { getAllLieux, getCacheStatus, getLieuById, getOpeningHoursCache, getSources, invalidateCache } from './lieux-cache';
 export { OpeningHoursCache } from './opening-hours-cache';

--- a/src/libraries/lieux-cache/lieux-cache.ts
+++ b/src/libraries/lieux-cache/lieux-cache.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { inclusionNumeriqueFetchApi, LIEUX_ROUTE, type LieuxRouteResponse } from '@/libraries/inclusion-numerique-api';
 import { OpeningHoursCache } from './opening-hours-cache';
 
@@ -9,10 +10,30 @@ type LieuxStore = {
   openingHours: OpeningHoursCache;
 };
 
+// Identity of THIS module instance. If the same process reports more than one
+// instanceId (same pid), the module is duplicated across server bundles; if the
+// pid also differs, requests are hitting distinct replicas. Either way it tells
+// us which store a given request was served from.
+const instanceId = randomUUID();
+const startedAt = new Date().toISOString();
+
 let currentData: Promise<LieuxRouteResponse> | null = null;
 let currentStore: Promise<LieuxStore> | null = null;
 let currentRefresh: Promise<void> | null = null;
 let lastRefreshedAt: string | null = null;
+let storeBuiltAt: string | null = null;
+let lastTrigger: 'lazy' | 'refresh' | null = null;
+let buildCount = 0;
+let size: number | null = null;
+
+const recordBuild = (data: LieuxRouteResponse, trigger: 'lazy' | 'refresh'): void => {
+  const now = new Date().toISOString();
+  storeBuiltAt ??= now;
+  lastRefreshedAt = now;
+  lastTrigger = trigger;
+  buildCount += 1;
+  size = data.length;
+};
 
 const collator = new Intl.Collator('fr', { sensitivity: 'base' });
 
@@ -39,7 +60,7 @@ const getStore = (): Promise<LieuxStore> => {
     currentStore = getData()
       .then((data) => {
         const store = buildStore(data);
-        lastRefreshedAt = new Date().toISOString();
+        recordBuild(data, 'lazy');
         return store;
       })
       .catch((error: unknown) => {
@@ -56,7 +77,7 @@ export const invalidateCache = async (): Promise<void> => {
     .then((data) => {
       currentData = Promise.resolve(data);
       currentStore = Promise.resolve(buildStore(data));
-      lastRefreshedAt = new Date().toISOString();
+      recordBuild(data, 'refresh');
     })
     .finally(() => {
       currentRefresh = null;
@@ -73,4 +94,26 @@ export const getLieuById = async (id: string): Promise<Lieu | undefined> => (awa
 
 export const getOpeningHoursCache = async (): Promise<OpeningHoursCache> => (await getStore()).openingHours;
 
-export const getCacheStatus = (): { lastRefreshedAt: string | null } => ({ lastRefreshedAt });
+export type CacheStatus = {
+  instanceId: string;
+  pid: number;
+  uptimeSec: number;
+  startedAt: string;
+  storeBuiltAt: string | null;
+  lastRefreshedAt: string | null;
+  lastTrigger: 'lazy' | 'refresh' | null;
+  buildCount: number;
+  size: number | null;
+};
+
+export const getCacheStatus = (): CacheStatus => ({
+  instanceId,
+  pid: process.pid,
+  uptimeSec: Math.round(process.uptime()),
+  startedAt,
+  storeBuiltAt,
+  lastRefreshedAt,
+  lastTrigger,
+  buildCount,
+  size
+});


### PR DESCRIPTION
Add per-instance observability to pin down why deleted lieux keep a live fiche in prod: the in-memory lieux store is a module-level singleton that gets duplicated across the RSC/pages and route-handler bundle layers, so POST /api/cache/reset only refreshes one copy while generateMetadata reads the other (stale) one.

- lieux-cache: tag each module instance (instanceId, pid) and track storeBuiltAt/buildCount/size/lastTrigger; expose via getCacheStatus()
- /api/health: return the enriched status (instance census when polled)
- instrumentation: log lieux-cache.warm on boot
- /api/cache/reset: log lieux-cache.reset (which instance it touched) and return the cache status in the response
- fiche generateMetadata: log lieu-detail.render with the serving instanceId + found, the smoking-gun signal (group by instance in Loki)

Observability only; no behavior change to the cache itself.