### PR TITLE
fix(lieux-cache): share store across bundle layers via globalThis singleton

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -366,7 +366,7 @@ const LIBRARY_DEPENDENCIES = {
   analytics: ['injection'],
   nextjs: ['injection'],
   'inclusion-numerique-api': ['api', 'utils', 'collectivites', 'ban', 'injection'],
-  'lieux-cache': ['inclusion-numerique-api', 'collectivites'],
+  'lieux-cache': ['inclusion-numerique-api', 'collectivites', 'nextjs'],
   collectivites: [],
   map: [],
   ban: [],

--- a/src/libraries/lieux-cache/lieux-cache.ts
+++ b/src/libraries/lieux-cache/lieux-cache.ts
@@ -10,29 +10,49 @@ type LieuxStore = {
   openingHours: OpeningHoursCache;
 };
 
-// Identity of THIS module instance. If the same process reports more than one
-// instanceId (same pid), the module is duplicated across server bundles; if the
-// pid also differs, requests are hitting distinct replicas. Either way it tells
-// us which store a given request was served from.
-const instanceId = randomUUID();
-const startedAt = new Date().toISOString();
+type LieuxCacheState = {
+  instanceId: string;
+  startedAt: string;
+  currentData: Promise<LieuxRouteResponse> | null;
+  currentStore: Promise<LieuxStore> | null;
+  currentRefresh: Promise<void> | null;
+  lastRefreshedAt: string | null;
+  storeBuiltAt: string | null;
+  lastTrigger: 'lazy' | 'refresh' | null;
+  buildCount: number;
+  size: number | null;
+};
 
-let currentData: Promise<LieuxRouteResponse> | null = null;
-let currentStore: Promise<LieuxStore> | null = null;
-let currentRefresh: Promise<void> | null = null;
-let lastRefreshedAt: string | null = null;
-let storeBuiltAt: string | null = null;
-let lastTrigger: 'lazy' | 'refresh' | null = null;
-let buildCount = 0;
-let size: number | null = null;
+// Anchor the store on globalThis so the two copies of this module — Next bundles
+// it once per server layer (RSC/pages vs route handlers) — share ONE store.
+// Without this, POST /api/cache/reset refreshes only the route-handler copy while
+// pages (generateMetadata, the fiche withFetch) keep serving a stale store built
+// at process start. globalThis is process-scoped, so this still needs a separate
+// answer for multi-replica autoscaling (a single reset reaches only one process).
+const globalStore = globalThis as typeof globalThis & { __lieuxCache?: LieuxCacheState };
+if (!globalStore.__lieuxCache) {
+  globalStore.__lieuxCache = {
+    instanceId: randomUUID(),
+    startedAt: new Date().toISOString(),
+    currentData: null,
+    currentStore: null,
+    currentRefresh: null,
+    lastRefreshedAt: null,
+    storeBuiltAt: null,
+    lastTrigger: null,
+    buildCount: 0,
+    size: null
+  };
+}
+const state = globalStore.__lieuxCache;
 
 const recordBuild = (data: LieuxRouteResponse, trigger: 'lazy' | 'refresh'): void => {
   const now = new Date().toISOString();
-  storeBuiltAt ??= now;
-  lastRefreshedAt = now;
-  lastTrigger = trigger;
-  buildCount += 1;
-  size = data.length;
+  state.storeBuiltAt ??= now;
+  state.lastRefreshedAt = now;
+  state.lastTrigger = trigger;
+  state.buildCount += 1;
+  state.size = data.length;
 };
 
 const collator = new Intl.Collator('fr', { sensitivity: 'base' });
@@ -44,45 +64,47 @@ const buildStore = (data: LieuxRouteResponse): LieuxStore => ({
 });
 
 const getData = (): Promise<LieuxRouteResponse> => {
-  if (!currentData) {
-    currentData = inclusionNumeriqueFetchApi(LIEUX_ROUTE, {}, undefined, { noCache: true })
+  if (!state.currentData) {
+    state.currentData = inclusionNumeriqueFetchApi(LIEUX_ROUTE, {}, undefined, { noCache: true })
       .then(([data]) => data)
       .catch((error: unknown) => {
-        currentData = null;
+        state.currentData = null;
         throw error;
       });
   }
-  return currentData;
+  return state.currentData;
 };
 
 const getStore = (): Promise<LieuxStore> => {
-  if (!currentStore) {
-    currentStore = getData()
+  if (!state.currentStore) {
+    state.currentStore = getData()
       .then((data) => {
         const store = buildStore(data);
         recordBuild(data, 'lazy');
         return store;
       })
       .catch((error: unknown) => {
-        currentStore = null;
+        state.currentStore = null;
         throw error;
       });
   }
-  return currentStore;
+  return state.currentStore;
 };
 
 export const invalidateCache = async (): Promise<void> => {
-  currentRefresh ??= inclusionNumeriqueFetchApi(LIEUX_ROUTE, {}, undefined, { noCache: true })
-    .then(([data]) => data)
-    .then((data) => {
-      currentData = Promise.resolve(data);
-      currentStore = Promise.resolve(buildStore(data));
-      recordBuild(data, 'refresh');
-    })
-    .finally(() => {
-      currentRefresh = null;
-    });
-  return currentRefresh;
+  if (!state.currentRefresh) {
+    state.currentRefresh = inclusionNumeriqueFetchApi(LIEUX_ROUTE, {}, undefined, { noCache: true })
+      .then(([data]) => data)
+      .then((data) => {
+        state.currentData = Promise.resolve(data);
+        state.currentStore = Promise.resolve(buildStore(data));
+        recordBuild(data, 'refresh');
+      })
+      .finally(() => {
+        state.currentRefresh = null;
+      });
+  }
+  return state.currentRefresh;
 };
 
 export const getAllLieux = async (): Promise<LieuxRouteResponse> => (await getStore()).all;
@@ -107,13 +129,13 @@ export type CacheStatus = {
 };
 
 export const getCacheStatus = (): CacheStatus => ({
-  instanceId,
+  instanceId: state.instanceId,
   pid: process.pid,
   uptimeSec: Math.round(process.uptime()),
-  startedAt,
-  storeBuiltAt,
-  lastRefreshedAt,
-  lastTrigger,
-  buildCount,
-  size
+  startedAt: state.startedAt,
+  storeBuiltAt: state.storeBuiltAt,
+  lastRefreshedAt: state.lastRefreshedAt,
+  lastTrigger: state.lastTrigger,
+  buildCount: state.buildCount,
+  size: state.size
 });

--- a/src/libraries/lieux-cache/lieux-cache.ts
+++ b/src/libraries/lieux-cache/lieux-cache.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { inclusionNumeriqueFetchApi, LIEUX_ROUTE, type LieuxRouteResponse } from '@/libraries/inclusion-numerique-api';
+import { sharedAcrossBundles } from '@/libraries/nextjs/shared-across-bundles';
 import { OpeningHoursCache } from './opening-hours-cache';
 
 type Lieu = LieuxRouteResponse[number];
@@ -23,15 +24,12 @@ type LieuxCacheState = {
   size: number | null;
 };
 
-// Anchor the store on globalThis so the two copies of this module — Next bundles
-// it once per server layer (RSC/pages vs route handlers) — share ONE store.
-// Without this, POST /api/cache/reset refreshes only the route-handler copy while
-// pages (generateMetadata, the fiche withFetch) keep serving a stale store built
-// at process start. globalThis is process-scoped, so this still needs a separate
-// answer for multi-replica autoscaling (a single reset reaches only one process).
-const globalStore = globalThis as typeof globalThis & { __lieuxCache?: LieuxCacheState };
-if (!globalStore.__lieuxCache) {
-  globalStore.__lieuxCache = {
+// One store per process, shared across Next's server bundle layers so that
+// POST /api/cache/reset (route-handler layer) and the fiche (pages layer) read
+// the same instance. Still per-replica — multi-replica is handled separately.
+const state = sharedAcrossBundles(
+  'lieux-cache',
+  (): LieuxCacheState => ({
     instanceId: randomUUID(),
     startedAt: new Date().toISOString(),
     currentData: null,
@@ -42,9 +40,8 @@ if (!globalStore.__lieuxCache) {
     lastTrigger: null,
     buildCount: 0,
     size: null
-  };
-}
-const state = globalStore.__lieuxCache;
+  })
+);
 
 const recordBuild = (data: LieuxRouteResponse, trigger: 'lazy' | 'refresh'): void => {
   const now = new Date().toISOString();

--- a/src/libraries/nextjs/index.ts
+++ b/src/libraries/nextjs/index.ts
@@ -1,1 +1,2 @@
 export * from './href-with-search-params';
+export * from './shared-across-bundles';

--- a/src/libraries/nextjs/shared-across-bundles.spec.ts
+++ b/src/libraries/nextjs/shared-across-bundles.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { sharedAcrossBundles } from './shared-across-bundles';
+
+describe('sharedAcrossBundles', () => {
+  it('should build the value once and return the same instance for a given name', () => {
+    const first = sharedAcrossBundles('test:same', () => ({ n: 1 }));
+    const second = sharedAcrossBundles('test:same', () => ({ n: 2 }));
+
+    expect(second).toBe(first);
+    expect(second.n).toBe(1);
+  });
+
+  it('should keep distinct values for distinct names', () => {
+    const a = sharedAcrossBundles('test:a', () => ({ id: 'a' }));
+    const b = sharedAcrossBundles('test:b', () => ({ id: 'b' }));
+
+    expect(a).not.toBe(b);
+    expect(a.id).toBe('a');
+    expect(b.id).toBe('b');
+  });
+});

--- a/src/libraries/nextjs/shared-across-bundles.ts
+++ b/src/libraries/nextjs/shared-across-bundles.ts
@@ -1,0 +1,24 @@
+/**
+ * Next.js compiles a module once per server bundle layer (the RSC/pages layer and
+ * the route-handler layer resolve it under different conditions), so module-level
+ * state (`let x = …`) is evaluated — and therefore duplicated — in each. Anything
+ * meant to be a single source of truth across those layers must live somewhere the
+ * bundles share: globalThis (one per realm/process).
+ *
+ * `sharedAcrossBundles` returns the same instance for a given name regardless of
+ * which bundle asks. The factory runs at most once per process.
+ *
+ * Process-scoped: this bridges the in-process bundle split, NOT multiple replicas —
+ * each replica keeps its own copy.
+ */
+export const sharedAcrossBundles = <T>(name: string, create: () => T): T => {
+  const globalScope = globalThis as typeof globalThis & { __sharedAcrossBundles?: Map<string, unknown> };
+  if (!globalScope.__sharedAcrossBundles) {
+    globalScope.__sharedAcrossBundles = new Map();
+  }
+  const registry = globalScope.__sharedAcrossBundles;
+  if (!registry.has(name)) {
+    registry.set(name, create());
+  }
+  return registry.get(name) as T;
+};


### PR DESCRIPTION
The in-memory lieux store and the piqure DI registry kept their state in module-level variables. Next bundles these modules once per server layer (RSC/pages vs route handlers), so each layer got its own copy: POST /api/cache/reset refreshed only the route-handler store while the fiche (generateMetadata) kept reading a stale pages-layer store built at process start — deleted lieux stayed live and newly-created ones 404'd until redeploy.

Confirmed in prod via the observability logs: same pid (3), two instanceIds (pages 74559116 / routes 76bf4677), two distinct storeBuiltAt.

- lieux-cache: hold the store state on globalThis.__lieuxCache
- injection/container: hold the piqure registry on globalThis.__piqureMemory (fixes the same latent duplication for every DI value, not just the store)

Process-scoped: does NOT address multi-replica (maxScale 5) — a single reset still reaches only one process. Tracked separately.